### PR TITLE
Run Github Actions on PR trigger

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: "CI"
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
Closes #4 

- Execute Github Action on PR event (instead of push+pr event which would trigger the action twice on pull requests)