### PR TITLE
Improve admin display for Provider and SafeApp

### DIFF
--- a/src/safe_apps/admin.py
+++ b/src/safe_apps/admin.py
@@ -12,12 +12,10 @@ class NetworksFilter(admin.SimpleListFilter):
         # lookups requires a tuple to be returned – (value, verbose value)
         networks = [(network, network) for networks in values for network in networks]
         networks = sorted(set(networks))
-        print(networks)
         return networks
 
     def queryset(self, request, queryset):
-        value = self.value()
-        if value:
+        if value := self.value():
             queryset = queryset.filter(networks__contains=[value])
         return queryset
 

--- a/src/safe_apps/admin.py
+++ b/src/safe_apps/admin.py
@@ -2,5 +2,36 @@ from django.contrib import admin
 
 from .models import SafeApp, Provider
 
-models = [SafeApp, Provider]
-admin.site.register(models)
+
+class NetworksFilter(admin.SimpleListFilter):
+    title = 'Networks'
+    parameter_name = 'networks'
+
+    def lookups(self, request, model_admin):
+        values = SafeApp.objects.values_list('networks', flat=True)
+        # lookups requires a tuple to be returned – (value, verbose value)
+        networks = [(network, network) for networks in values for network in networks]
+        networks = sorted(set(networks))
+        print(networks)
+        return networks
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if value:
+            queryset = queryset.filter(networks__contains=[value])
+        return queryset
+
+
+@admin.register(SafeApp)
+class SafeAppAdmin(admin.ModelAdmin):
+    list_display = ('name', 'url', 'networks')
+    list_filter = (NetworksFilter,)
+    search_fields = ('name', 'url')
+    ordering = ('name',)
+
+
+@admin.register(Provider)
+class ProviderAdmin(admin.ModelAdmin):
+    list_display = ('name', 'url')
+    search_fields = ('name',)
+    ordering = ('name',)


### PR DESCRIPTION
Closes #11 

- Add `list_display`, `list_filter`, `search_fields` and `ordering` to the admin pages of `SafeApp` and `Provider`
- Add `NetworksFilter` to provider a filter over the array of networks for each app
  * Since each `SafeApp` contains a list of networks, this list needs to be flattened and converted to a set
- Use `@admin.register` decorator for `SafeApp` and `Provider`