### PR TITLE
Use FactoryBoy for generating test data

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 pytest-django==4.2.0
 flake8==3.9.1
+factory-boy==3.2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
-pytest-django==4.2.0
-flake8==3.9.1
 factory-boy==3.2.0
+flake8==3.9.1
+pytest-django==4.2.0

--- a/src/safe_apps/tests/factories.py
+++ b/src/safe_apps/tests/factories.py
@@ -1,0 +1,24 @@
+import factory
+from factory.django import DjangoModelFactory
+
+from ..models import Provider, SafeApp
+
+
+class ProviderFactory(DjangoModelFactory):
+    class Meta:
+        model = Provider
+
+    name = factory.Faker('company')
+    url = factory.Faker('url')
+
+
+class SafeAppFactory(DjangoModelFactory):
+    class Meta:
+        model = SafeApp
+
+    url = factory.Faker('url')
+    name = factory.Faker('company')
+    icon_url = factory.Faker('image_url')
+    description = factory.Faker('catch_phrase')
+    networks = factory.Faker('pylist', nb_elements=2, value_types=(int,))
+    provider = None

--- a/src/safe_apps/tests/test_views.py
+++ b/src/safe_apps/tests/test_views.py
@@ -3,7 +3,7 @@ import json
 from django.urls import reverse
 from rest_framework.test import APITestCase
 
-from ..models import SafeApp, Provider
+from .factories import ProviderFactory, SafeAppFactory
 
 
 class EmptySafeAppsListViewTests(APITestCase):
@@ -16,88 +16,33 @@ class EmptySafeAppsListViewTests(APITestCase):
         self.assertEqual(json.loads(response.content), [])
 
 
-class SingleSafeAppListViewTests(APITestCase):
-
-    def setUp(self) -> None:
-        SafeApp.objects.create(
-            url="https://example.com",
-            name="test_safe_app",
-            icon_url="https://example.com/icon",
-            description="safe_app_description",
-            networks=[1]
-        )
-
-    def test_safe_app_returned(self):
-        json_response = [{
-            'url': 'https://example.com',
-            'name': 'test_safe_app',
-            'icon_url': 'https://example.com/icon',
-            'description': 'safe_app_description',
-            'networks': [1],
-            'provider': None
-        }]
-        url = reverse('v1:safe-apps')
-
-        response = self.client.get(path=url, data=None, format='json')
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), json_response)
-
-
 class FilterSafeAppListViewTests(APITestCase):
 
-    def setUp(self) -> None:
-        SafeApp.objects.create(
-            url="https://example.com/1",
-            name="test_safe_app_1",
-            icon_url="https://example.com/icon",
-            description="safe_app_description_1",
-            networks=[1],
-            provider=None
-        )
-
-        SafeApp.objects.create(
-            url="https://example.com/2",
-            name="test_safe_app_2",
-            icon_url="https://example.com/icon",
-            description="safe_app_description_2",
-            networks=[1],
-            provider=None
-        )
-
-        SafeApp.objects.create(
-            url="https://example.com/3",
-            name="test_safe_app_3",
-            icon_url="https://example.com/icon",
-            description="safe_app_description_3",
-            networks=[2],
-            provider=None
-        )
-
     def test_all_safes_returned(self):
+        (safe_app_1, safe_app_2, safe_app_3) = SafeAppFactory.create_batch(3)
         json_response = [
             {
-                'url': 'https://example.com/1',
-                'name': 'test_safe_app_1',
-                'icon_url': 'https://example.com/icon',
-                'description': 'safe_app_description_1',
-                'networks': [1],
+                'url': safe_app_1.url,
+                'name': safe_app_1.name,
+                'icon_url': safe_app_1.icon_url,
+                'description': safe_app_1.description,
+                'networks': safe_app_1.networks,
                 'provider': None
             },
             {
-                'url': 'https://example.com/2',
-                'name': 'test_safe_app_2',
-                'icon_url': 'https://example.com/icon',
-                'description': 'safe_app_description_2',
-                'networks': [1],
+                'url': safe_app_2.url,
+                'name': safe_app_2.name,
+                'icon_url': safe_app_2.icon_url,
+                'description': safe_app_2.description,
+                'networks': safe_app_2.networks,
                 'provider': None
             },
             {
-                'url': 'https://example.com/3',
-                'name': 'test_safe_app_3',
-                'icon_url': 'https://example.com/icon',
-                'description': 'safe_app_description_3',
-                'networks': [2],
+                'url': safe_app_3.url,
+                'name': safe_app_3.name,
+                'icon_url': safe_app_3.icon_url,
+                'description': safe_app_3.description,
+                'networks': safe_app_3.networks,
                 'provider': None
             },
         ]
@@ -109,29 +54,30 @@ class FilterSafeAppListViewTests(APITestCase):
         self.assertEqual(json.loads(response.content), json_response)
 
     def test_all_apps_returned_on_empty_network_value(self):
+        (safe_app_1, safe_app_2, safe_app_3) = SafeAppFactory.create_batch(3)
         json_response = [
             {
-                'url': 'https://example.com/1',
-                'name': 'test_safe_app_1',
-                'icon_url': 'https://example.com/icon',
-                'description': 'safe_app_description_1',
-                'networks': [1],
+                'url': safe_app_1.url,
+                'name': safe_app_1.name,
+                'icon_url': safe_app_1.icon_url,
+                'description': safe_app_1.description,
+                'networks': safe_app_1.networks,
                 'provider': None
             },
             {
-                'url': 'https://example.com/2',
-                'name': 'test_safe_app_2',
-                'icon_url': 'https://example.com/icon',
-                'description': 'safe_app_description_2',
-                'networks': [1],
+                'url': safe_app_2.url,
+                'name': safe_app_2.name,
+                'icon_url': safe_app_2.icon_url,
+                'description': safe_app_2.description,
+                'networks': safe_app_2.networks,
                 'provider': None
             },
             {
-                'url': 'https://example.com/3',
-                'name': 'test_safe_app_3',
-                'icon_url': 'https://example.com/icon',
-                'description': 'safe_app_description_3',
-                'networks': [2],
+                'url': safe_app_3.url,
+                'name': safe_app_3.name,
+                'icon_url': safe_app_3.icon_url,
+                'description': safe_app_3.description,
+                'networks': safe_app_3.networks,
                 'provider': None
             },
         ]
@@ -143,21 +89,24 @@ class FilterSafeAppListViewTests(APITestCase):
         self.assertEqual(json.loads(response.content), json_response)
 
     def test_apps_returned_on_filtered_network(self):
+        SafeAppFactory.create_batch(3, networks=[10])
+        (safe_app_4, safe_app_5) = SafeAppFactory.create_batch(2, networks=[1])
+
         json_response = [
             {
-                'url': 'https://example.com/1',
-                'name': 'test_safe_app_1',
-                'icon_url': 'https://example.com/icon',
-                'description': 'safe_app_description_1',
-                'networks': [1],
+                'url': safe_app_4.url,
+                'name': safe_app_4.name,
+                'icon_url': safe_app_4.icon_url,
+                'description': safe_app_4.description,
+                'networks': safe_app_4.networks,
                 'provider': None
             },
             {
-                'url': 'https://example.com/2',
-                'name': 'test_safe_app_2',
-                'icon_url': 'https://example.com/icon',
-                'description': 'safe_app_description_2',
-                'networks': [1],
+                'url': safe_app_5.url,
+                'name': safe_app_5.name,
+                'icon_url': safe_app_5.icon_url,
+                'description': safe_app_5.description,
+                'networks': safe_app_5.networks,
                 'provider': None
             }
         ]
@@ -169,6 +118,7 @@ class FilterSafeAppListViewTests(APITestCase):
         self.assertEqual(json.loads(response.content), json_response)
 
     def test_apps_returned_on_unexisting_network(self):
+        SafeAppFactory.create_batch(3, networks=[12])
         json_response = []
         url = reverse('v1:safe-apps') + f'{"?network_id=10"}'
 
@@ -178,21 +128,15 @@ class FilterSafeAppListViewTests(APITestCase):
         self.assertEqual(json.loads(response.content), json_response)
 
     def test_apps_returned_on_same_key_pair(self):
+        safe_app_1 = SafeAppFactory.create(networks=[1])
+        SafeAppFactory.create(networks=[2])
         json_response = [
             {
-                'url': 'https://example.com/1',
-                'name': 'test_safe_app_1',
-                'icon_url': 'https://example.com/icon',
-                'description': 'safe_app_description_1',
-                'networks': [1],
-                'provider': None
-            },
-            {
-                'url': 'https://example.com/2',
-                'name': 'test_safe_app_2',
-                'icon_url': 'https://example.com/icon',
-                'description': 'safe_app_description_2',
-                'networks': [1],
+                'url': safe_app_1.url,
+                'name': safe_app_1.name,
+                'icon_url': safe_app_1.icon_url,
+                'description': safe_app_1.description,
+                'networks': safe_app_1.networks,
                 'provider': None
             }
         ]
@@ -205,44 +149,25 @@ class FilterSafeAppListViewTests(APITestCase):
 
 
 class ProviderInfoTests(APITestCase):
-    def setUp(self) -> None:
-        provider = Provider.objects.create(
-            url="https://provider1.com",
-            name="Provider 1"
-        )
-
-        SafeApp.objects.create(
-            url="https://example.com/1",
-            name="test_safe_app_1",
-            icon_url="https://example.com/icon",
-            description="safe_app_description_1",
-            networks=[1],
-            provider=provider
-        )
-
-        SafeApp.objects.create(
-            url="https://example.com/2",
-            name="test_safe_app_2",
-            icon_url="https://example.com/icon",
-            description="safe_app_description_2",
-            networks=[2]
-        )
 
     def test_provider_returned_in_response(self):
+        provider = ProviderFactory.create()
+        safe_app = SafeAppFactory.create(provider=provider)
+
         json_response = [
             {
-                'url': 'https://example.com/1',
-                'name': 'test_safe_app_1',
-                'icon_url': 'https://example.com/icon',
-                'description': 'safe_app_description_1',
-                'networks': [1],
+                'url': safe_app.url,
+                'name': safe_app.name,
+                'icon_url': safe_app.icon_url,
+                'description': safe_app.description,
+                'networks': safe_app.networks,
                 'provider': {
-                    'name': 'Provider 1',
-                    'url': 'https://provider1.com'
+                    'name': provider.name,
+                    'url': provider.url
                 }
             }
         ]
-        url = reverse('v1:safe-apps') + f'{"?network_id=2&network_id=1"}'
+        url = reverse('v1:safe-apps')
 
         response = self.client.get(path=url, data=None, format='json')
 
@@ -250,17 +175,19 @@ class ProviderInfoTests(APITestCase):
         self.assertEqual(json.loads(response.content), json_response)
 
     def test_provider_not_returned_in_response(self):
+        safe_app = SafeAppFactory.create()
+
         json_response = [
             {
-                'url': 'https://example.com/2',
-                'name': 'test_safe_app_2',
-                'icon_url': 'https://example.com/icon',
-                'description': 'safe_app_description_2',
-                'networks': [2],
-                'provider': None,
+                'url': safe_app.url,
+                'name': safe_app.name,
+                'icon_url': safe_app.icon_url,
+                'description': safe_app.description,
+                'networks': safe_app.networks,
+                'provider': None
             }
         ]
-        url = reverse('v1:safe-apps') + f'{"?network_id=2&network_id=2"}'
+        url = reverse('v1:safe-apps')
 
         response = self.client.get(path=url, data=None, format='json')
 


### PR DESCRIPTION
Closes #9 

- Adds a factory for `Provider` and `SafeApp` so that test data can be generated more easily