### PR TITLE
Add Black pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 21.4b2
+    hooks:
+      - id: black
+        language_version: python3

--- a/README.md
+++ b/README.md
@@ -89,3 +89,38 @@ Example: if you want to issue a command to the image which is running the Django
 ```shell
 ./run manage <django-command>
 ```
+
+## Development Tools
+
+The project uses a variety of tools to make sure that the styling, health and correctness are validated on each change.
+These tools are available via `requirements-dev.txt` so to have them available in your virtual environment run:
+
+```shell
+pip install -r requirements-dev.txt
+```
+
+### Testing
+
+Pytest is used to run the available tests in the project. Some of these tests validate the integration with the database
+so having one running is required. From the project root:
+
+```shell
+pytest src
+```
+
+### Code Style Formatter and Linter
+
+[Black](https://black.readthedocs.io/en/stable/) and [Flake8](https://flake8.pycqa.org/en/latest/) are the tools used to validate the style of the changes being pushed. You can refer to the documentation
+of these tools to check how to integrate them with your editor/IDE.
+
+```shell
+black src # formats the files in the src folder using Black
+flake8 src # runs flake8 Linter in the src folder
+```
+
+There's also a pre-commit hook that you can install locally via `pre-commit` so that it formats the files changed on each commit automatically:
+
+```shell
+pre-commit install # installs commit hook under .git/hooks/pre-commit
+git commit # Initially this can take a couple minutes to setup the environment (which will be reused in following commits)
+```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,5 @@
 black==21.4b2
 factory-boy==3.2.0
 flake8==3.9.1
+pre-commit==2.12.1
 pytest-django==4.2.0


### PR DESCRIPTION
Part of #19 

- Adds a pre-commit hook to run `Black` on changed files – to install the hook, run `pre-commit install`
- Updates documentation on the tools used for development