### PR TITLE
Use Nginx templates to replace environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,14 @@ ALLOWED_HOSTS=".localhost,127.0.0.1,[::1]"
 # Be warned that if you change this value you'll need to change 8000 in both
 # your Dockerfile and in a few spots in docker-compose.yml due to the nature of
 # how this value can be set (Docker Compose doesn't support nested ENV vars).
-#PORT=8000
+GUNICORN_BIND_PORT=8000
+
+# The port exposed to the host by the nginx image.
+NGINX_HOST_PORT=8080
+
+# A directory where the result of executing envsubst is output (default: /etc/nginx/conf.d)
+# Used by the nginx docker image in the templating system in order to use the environment variables set
+NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx/
 
 # Should the Webpack watcher use polling? Not all Docker hosts support inotify.
 # If you find your assets aren't updating in development then set this to true.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,14 @@ version: "3.9"
 services:
   nginx:
     image: nginx:1.20-alpine
-    hostname: nginx
     links:
       - web:web
+    env_file:
+      - .env
     ports:
-      - "8080:80"
+      - "${NGINX_HOST_PORT}:80"
     volumes:
-      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/templates:/etc/nginx/templates
     depends_on:
       - web
   db:
@@ -19,13 +20,13 @@ services:
     volumes:
       - ./data/db:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT}:${POSTGRES_PORT}"
   web:
     build: .
     tty: true
     env_file:
       - .env
-    command: gunicorn -c python:config.gunicorn config.wsgi -b 0.0.0.0:8000
+    command: gunicorn -c python:config.gunicorn config.wsgi -b 0.0.0.0:${GUNICORN_BIND_PORT}
     working_dir: /app/src
     depends_on:
       - db

--- a/nginx/templates/nginx.conf.template
+++ b/nginx/templates/nginx.conf.template
@@ -25,7 +25,7 @@ http {
       # server unix:/run/gunicorn.sock fail_timeout=0;
 
       # for a TCP configuration
-      server web:8000 fail_timeout=0;
+      server web:${GUNICORN_BIND_PORT} fail_timeout=0;
       keepalive 32;
     }
 

--- a/src/config/gunicorn.py
+++ b/src/config/gunicorn.py
@@ -2,7 +2,7 @@ import multiprocessing
 import os
 from distutils.util import strtobool
 
-bind = f"0.0.0.0:{os.getenv('PORT', '8000')}"
+bind = f"0.0.0.0:{os.getenv('GUNICORN_BIND_PORT', '8000')}"
 accesslog = "-"
 
 workers = int(os.getenv("WEB_CONCURRENCY", multiprocessing.cpu_count() * 2))


### PR DESCRIPTION
Closes #22 

- Extract port variables to the `.env` file
- Use Nginx templating system
  * This allows that one template of a nginx configuration with environment variables correctly generates a configuration with those environment variables set
  * The nginx image will look for those templates in the image location `/etc/nginx/templates`
  * The `NGINX_ENVSUBST_OUTPUT_DIR` is an environment variable used by nginx – the path set here is the path where the generated configs (with the environment variables replaced) will be stored