### PR TITLE
Remove defaults for some production environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@
 PYTHONDONTWRITEBYTECODE=true
 
 # You should generate a random string of 50+ characters for this value in prod.
-SECRET_KEY=insecure_key_for_dev
+# SECRET_KEY=insecure_key_for_dev
 
 # This should never be set to true in production but it should be enabled in dev.
 DEBUG=false
@@ -43,23 +43,11 @@ NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx/
 
 # You'll always want to set the POSTGRES_USER and POSTGRES_PASSWORD since the
 # postgres Docker image uses them for its default database user and password.
+#POSTGRES_USER=postgres
+#POSTGRES_PASSWORD=postgres
 POSTGRES_NAME=postgres
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
 POSTGRES_HOST=db
 POSTGRES_PORT=5432
-
-# What ip:port should be published back to the Docker host for the app server?
-# If you're using Docker Toolbox or a custom VM you can't use 127.0.0.1. This
-# is being overwritten in dev to be compatible with more dev environments.
-#
-# If you have a port conflict because something else is using 8000 then you
-# can either stop that process or change this 8000 to be something else.
-#
-# Use the default in production to avoid having gunicorn directly accessible to
-# the internet without assistance from a cloud based firewall.
-#DOCKER_WEB_PORT_FORWARD=127.0.0.1:8000
-DOCKER_WEB_PORT_FORWARD=8000
 
 # What volume path should be used? In development we want to volume mount
 # everything so we can develop our code without rebuilding our Docker images.

--- a/README.md
+++ b/README.md
@@ -14,11 +14,14 @@ The service uses Gunicorn+Nginx as a connection proxy, Django as the main applic
 
 ### 1. Configuration
 
-The environment variables are set via the `.env` file. The configuration in `.env.example` is meant to be production ready for the most part. You can copy it and adjust it to your development needs (refer to the file for the explanation about each environment variable)
+The environment variables are set via the `.env` file. The configuration in `.env.example` is meant to be production ready. You can copy it and adjust it to your development needs (refer to the file for the explanation about each environment variable).
 
 ```shell
 cp .env.example .env
 ```
+
+Some variables are required to be set before running the application: `SECRET_KEY`, `POSTGRES_USER`, `POSTGRES_PASSWORD`.
+They can be set either locally on your environment or (as a provided example) by uncommenting these variables from the `.env` file.
 
 ### 2. Service deployment/development
 

--- a/docker-compose.override.yml.ci
+++ b/docker-compose.override.yml.ci
@@ -1,0 +1,12 @@
+version: "3.9"
+
+# This file is used to provide additional environment variables to the images when running on CI
+# The provided .env.example file is optimized for production which means that some environment variables are empty
+
+
+services:
+  web:
+    environment:
+        - SECRET_KEY=insecure_key_for_dev
+        - POSTGRES_USER=postgres
+        - POSTGRES_PASSWORD=postgres

--- a/docker-compose.override.yml.ci
+++ b/docker-compose.override.yml.ci
@@ -3,10 +3,14 @@ version: "3.9"
 # This file is used to provide additional environment variables to the images when running on CI
 # The provided .env.example file is optimized for production which means that some environment variables are empty
 
+x-common-environment: &common-environment
+  POSTGRES_USER: postgres
+  POSTGRES_PASSWORD: postgres
 
 services:
+  db:
+    environment: *common-environment
   web:
     environment:
-        - SECRET_KEY=insecure_key_for_dev
-        - POSTGRES_USER=postgres
-        - POSTGRES_PASSWORD=postgres
+      <<: *common-environment
+      SECRET_KEY: 'insecure_key_for_dev'

--- a/run
+++ b/run
@@ -58,12 +58,12 @@ function isort {
 
 
 function ci:test {
-  cp --no-clobber .env.example .env
+  # Set environment
+  cp .env.example .env
+  cp docker-compose.override.yml.ci docker-compose.override.yml
 
   docker-compose build
   docker-compose up -d
-
-  . .env
 
   manage check
   isort --check --profile black .


### PR DESCRIPTION
This is part of a review of making the configuration production ready by default. It was, for the most part, production ready already.

Some relevant keys like `SECRET_KEY`, `POSTGRES_USER` and `POSTGRES_PASSWORD` do not have any defaults and require to be setup – the goal is to avoid having a default set into a production build accidentally.

Given that the images rely both on the `.env` file and these variables:
- While developing, we can just set these variables on the `.env` file (for practical reasons some defaults are provided in a comment)
- In the CI, these variables are set by overriding the environment via ` docker-compose.override.yml.ci` – (this can also be applied for local development)