### PR TITLE
Run Action on push event on any branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,6 @@
 name: "CI"
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
+on: push
 
 jobs:
   test:


### PR DESCRIPTION
- The Github Action is now triggered on a `push` event for any branch
- This allows branches that do not have any Pull Request open to get feedback on the current status of the build before opening the Pull Request

Sidenote: I took into consideration the discussion here https://github.com/gnosis/safe-config-service/pull/5#discussion_r622101396