### PR TITLE
Add Logging middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@ PYTHONDONTWRITEBYTECODE=true
 # This should never be set to true in production but it should be enabled in dev.
 DEBUG=false
 
+# Root log level (default is INFO)
+# Possible values are DEBUG | INFO | WARNING | ERROR | CRITICAL
+ROOT_LOG_LEVEL=INFO
+
 # A comma separated list of allowed hosts. In production this should be your
 # domain name, such as "example.com,www.example.com" or ".example.com" to
 # support both example.com and all sub-domains for your domain.

--- a/src/config/middleware.py
+++ b/src/config/middleware.py
@@ -1,0 +1,37 @@
+import logging
+import time
+
+from django.http import HttpRequest
+
+
+class LoggingMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self.logger = logging.getLogger("LoggingMiddleware")
+
+    @staticmethod
+    def get_milliseconds_now():
+        return int(time.time() * 1000)
+
+    def __call__(self, request: HttpRequest):
+        # before view (and other middleware) are called
+        milliseconds = self.get_milliseconds_now()
+
+        response = self.get_response(request)
+
+        # after view is called
+        if request.resolver_match:
+            route = (
+                request.resolver_match.route[1:]
+                if request.resolver_match
+                else request.path
+            )
+            self.logger.info(
+                "MT::%s::%s::%s::%d::%s",
+                request.method,
+                route,
+                self.get_milliseconds_now() - milliseconds,
+                response.status_code,
+                request.path,
+            )
+        return response

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "config.middleware.LoggingMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -51,6 +52,38 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "short": {"format": "%(asctime)s %(message)s"},
+        "verbose": {
+            "format": "%(asctime)s [%(levelname)s] [%(processName)s] %(message)s"
+        },
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "verbose",
+        },
+        "console_short": {
+            "class": "logging.StreamHandler",
+            "formatter": "short",
+        },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": os.getenv("ROOT_LOG_LEVEL", "INFO"),
+    },
+    "loggers": {
+        "LoggingMiddleware": {
+            "handlers": ["console_short"],
+            "level": "INFO",
+            "propagate": False,
+        },
+    },
+}
 
 ROOT_URLCONF = "config.urls"
 


### PR DESCRIPTION
Closes #26 

- Add a Logging middleware – this middleware logs endpoint request calls to `INFO`
- Add Django logging settings
  * A `root` logger that applies the configuration to loggers which are not declared in this dictionary. Default logging level is `INFO` (can be changed by setting `ROOT_LOG_LEVEL`)
  * A `LoggingMiddleware` that logs view requests to `INFO`. It currently logs the HTTP method used, the route and paht, the time that it took to process the request and the status of the response.