### PR TITLE
Propagate subcommand failure return code

### DIFF
--- a/run
+++ b/run
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eo pipefail
+
 DC="${DC:-exec}"
 
 # If we're running in CI we need to disable TTY allocation for docker-compose


### PR DESCRIPTION
- Propagate return code of each sub-command to the pipeline (by default it was taking the last one executed, in this case the tests)
- The `-eo pipefail` set the pipeline to exit earlier if if a return code is `>0` (ie.: not successful)