### PR TITLE
Cache GET /safe-apps/ endpoint

### DIFF
--- a/src/safe_apps/views.py
+++ b/src/safe_apps/views.py
@@ -9,7 +9,7 @@ from .serializers import SafeAppsResponseSerializer
 class SafeAppsListView(ListAPIView):
     serializer_class = SafeAppsResponseSerializer
 
-    @method_decorator(cache_page(60 * 60 * 1))  # Cache 1 hour
+    @method_decorator(cache_page(60 * 10))  # Cache 10 minutes
     def get(self, request, *args, **kwargs):
         return super().get(self, request, *args, **kwargs)
 

--- a/src/safe_apps/views.py
+++ b/src/safe_apps/views.py
@@ -1,3 +1,5 @@
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 from rest_framework.generics import ListAPIView
 
 from .models import SafeApp
@@ -6,6 +8,10 @@ from .serializers import SafeAppsResponseSerializer
 
 class SafeAppsListView(ListAPIView):
     serializer_class = SafeAppsResponseSerializer
+
+    @method_decorator(cache_page(60 * 60 * 1))  # Cache 1 hour
+    def get(self, request, *args, **kwargs):
+        return super().get(self, request, *args, **kwargs)
 
     def get_queryset(self):
         queryset = SafeApp.objects.all()


### PR DESCRIPTION
Closes #28 

- Cache `safe-apps` endpoint for 1h
- Update tests that do not required caching to use `DummyCache`
- Add test to test caching

### Some notes on key invalidation:

- It seems that adding view caching is relatively straightforward with `cache_page` but removing the cache entry when new data is added/updated/deleted seems to be complex
- The complexity comes from how Django generates the keys for cache entries they are based on the request that was made, the environment where the request was made, and header properties – https://github.com/django/django/blob/ca9872905559026af82000e46cde6f7dedc897b6/django/utils/cache.py#L347-L366
- Correctly recreating the key is possible as the information is deterministic but it'd be a custom solution on our side that might not work on later versions. Given this I decided to not invalidate those cache entries on these events.