### PR TITLE
Use different cache for view. Invalidate on update

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -53,6 +53,15 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+    },
+    "safe-apps": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+    },
+}
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/src/safe_apps/apps.py
+++ b/src/safe_apps/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class AppsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "safe_apps"
+
+    def ready(self):
+        import safe_apps.signals  # noqa: F401

--- a/src/safe_apps/signals.py
+++ b/src/safe_apps/signals.py
@@ -1,0 +1,18 @@
+import logging
+
+from django.core.cache import caches
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
+
+from .models import Provider, SafeApp
+
+logger = logging.getLogger(__name__)
+
+
+@receiver(post_save, sender=SafeApp)
+@receiver(post_delete, sender=SafeApp)
+@receiver(post_save, sender=Provider)
+@receiver(post_delete, sender=Provider)
+def on_safe_app_update(sender, **kwargs):
+    logger.info("Clearing safe-apps cache")
+    caches["safe-apps"].clear()

--- a/src/safe_apps/views.py
+++ b/src/safe_apps/views.py
@@ -9,7 +9,7 @@ from .serializers import SafeAppsResponseSerializer
 class SafeAppsListView(ListAPIView):
     serializer_class = SafeAppsResponseSerializer
 
-    @method_decorator(cache_page(60 * 10))  # Cache 10 minutes
+    @method_decorator(cache_page(60 * 10, cache="safe-apps"))  # Cache 10 minutes
     def get(self, request, *args, **kwargs):
         return super().get(self, request, *args, **kwargs)
 


### PR DESCRIPTION
Closes #31 

- Add `safe-apps` cache (which is a `LocMemCache`)
- Add signal which is triggered on `SafeApp` or `Provider` updates
- Test now checks if the response header `Cache-Control` returns the correct value