### PR TITLE
Add Docker deploy step for main branch

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,14 @@ __pycache__/
 venv/
 .idea/
 .pytest_cache/
+.coverage*
+htmlcov/
+data/
+.flake8
+.pre-commit-config.yaml
+docker-compose.override.yml
+docker-compose.override.yml.example
+docker-compose.yml
+pyproject.toml
+nginx/
+*.md

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -32,7 +32,7 @@ jobs:
           push: true
           # Target production image from multi-stage build (check Dockerfile)
           target: python-base
-          tags: gnosispm/safe-config-service:latest
+          tags: gnosispm/safe-config-service:staging
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
       - # Temp fix

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -9,10 +9,17 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
@@ -22,7 +29,17 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
+          context: .
           push: true
           tags: gnosispm/safe-config-service:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+      - # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -31,6 +31,8 @@ jobs:
         with:
           context: .
           push: true
+          # Target production image from multi-stage build (check Dockerfile)
+          target: python-base
           tags: gnosispm/safe-config-service:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -1,0 +1,28 @@
+name: Publish Staging Docker image
+on:
+  push:
+    branches:
+      - main
+      - add-docker-deploy
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: gnosispm/safe-config-service:latest
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -3,10 +3,9 @@ on:
   push:
     branches:
       - main
-      - add-docker-deploy
 
 jobs:
-  docker:
+  docker-publish:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
- Deploys production docker image to Docker Hub when the `main` branch is updated
- Cache docker layers with `cache-from` and `cache-to`
- Ignore files which are not required for the docker web image