### PR TITLE
Continue pipeline if coverage upload fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,6 +92,7 @@ jobs:
       - name: Run tests with coverage
         run: coverage run --source=src/ -m pytest src
       - name: Upload coverage
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: coveralls --service=github


### PR DESCRIPTION
Adding the `continue-on-error` to avoid an external service being down and blocking the PR