### PR TITLE
Add missing steps to production image

### DIFF
--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -31,7 +31,7 @@ jobs:
           context: .
           push: true
           # Target production image from multi-stage build (check Dockerfile)
-          target: python-base
+          target: production
           tags: gnosispm/safe-config-service:staging
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.4-alpine3.13 as python-base
+FROM python:3.9.4-alpine3.13 as production
 
 # python
 ENV PYTHONUNBUFFERED=1 \
@@ -12,22 +12,17 @@ ENV PYTHONUNBUFFERED=1 \
     CRYPTOGRAPHY_DONT_BUILD_RUST=1
 
 ENV PYTHONUSERBASE=/python-deps
+ENV PATH="${PATH}:${PYTHONUSERBASE}/bin"
 
 RUN set -ex \
     && apk add --no-cache --virtual .build-deps postgresql-dev build-base libffi-dev
 
-# Install Python deps
-COPY requirements.txt ./
+WORKDIR /app
+COPY . .
 RUN pip3 install --no-warn-script-location --user -r requirements.txt
 
 # ------- development image -------
+FROM production as development
 
-FROM python-base as development
 ENV PATH="${PATH}:${PYTHONUSERBASE}/bin"
-
-# venv already has runtime deps installed we get a quicker install
-COPY requirements-dev.txt ./
 RUN pip3 install --no-warn-script-location --user -r requirements-dev.txt
-
-WORKDIR /app
-COPY . .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,6 @@ services:
     tty: true
     env_file:
       - .env
-    command: gunicorn -c python:config.gunicorn config.wsgi -b 0.0.0.0:${GUNICORN_BIND_PORT}
-    working_dir: /app/src
+    command: gunicorn -c /app/src/config/gunicorn.py config.wsgi -b 0.0.0.0:${GUNICORN_BIND_PORT} --chdir /app/src/
     depends_on:
       - db


### PR DESCRIPTION
- Previously the Dockerfile was split into 2 stages:
  * `python-base` – base dependencies to build the project + installation of production dependencies
  * `development` – base + development dependencies

One issue here is that `python-base` didn't copy the application to the image and this was the stage that was being published to Docker Hub. To fix that issue and to make each stage more explicit these are the new stages:
  * `production` – base dependencies to build the project + copy of the application + production dependencies
  * `development` – production + installation of development dependencies