### PR TITLE
Add entrypoint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,18 @@ ENV PYTHONUSERBASE=/python-deps
 ENV PATH="${PATH}:${PYTHONUSERBASE}/bin"
 
 RUN set -ex \
-    && apk add --no-cache --virtual .build-deps postgresql-dev build-base libffi-dev
+    && apk add --no-cache --virtual .build-deps \
+    build-base \
+    libffi-dev \
+    postgresql-dev \
+    tini
 
 WORKDIR /app
 COPY . .
-RUN pip3 install --no-warn-script-location --user -r requirements.txt
+RUN pip3 install --no-warn-script-location --user -r requirements.txt \
+    && chmod +x docker-entrypoint.sh
+
+ENTRYPOINT ["/sbin/tini", "--", "./docker-entrypoint.sh"]
 
 # ------- development image -------
 FROM production as development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,5 @@ services:
     tty: true
     env_file:
       - .env
-    command: gunicorn -c /app/src/config/gunicorn.py config.wsgi -b 0.0.0.0:${GUNICORN_BIND_PORT} --chdir /app/src/
     depends_on:
       - db

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/ash
+
+set -euo pipefail
+
+echo "==> $(date +%H:%M:%S) ==> Migrating Django models..."
+python src/manage.py migrate --noinput
+
+echo "==> $(date +%H:%M:%S) ==> Applying fixtures..."
+python src/manage.py loaddata initial_default_apps.json
+
+echo "==> $(date +%H:%M:%S) ==> Running Gunicorn..."
+exec gunicorn -c /app/src/config/gunicorn.py config.wsgi -b 0.0.0.0:${GUNICORN_BIND_PORT} --chdir /app/src/

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,8 +5,5 @@ set -euo pipefail
 echo "==> $(date +%H:%M:%S) ==> Migrating Django models..."
 python src/manage.py migrate --noinput
 
-echo "==> $(date +%H:%M:%S) ==> Applying fixtures..."
-python src/manage.py loaddata initial_default_apps.json
-
 echo "==> $(date +%H:%M:%S) ==> Running Gunicorn..."
 exec gunicorn -c /app/src/config/gunicorn.py config.wsgi -b 0.0.0.0:${GUNICORN_BIND_PORT} --chdir /app/src/


### PR DESCRIPTION
Closes #43 

- Adds a Docker `ENTRYPOINT` to the production image (also applies to the dev image).
- The entrypoint performs the following:
  * Executes migrations
  ~* Loads initial fixture data using `manage.py loaddata` (this does not override current data)~
  * Launches app with `Gunicorn`