### PR TITLE
Add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: daily
+    reviewers:
+      - "fmrsabino"
+
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    reviewers:
+      - "fmrsabino"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    reviewers:
+      - "fmrsabino"


### PR DESCRIPTION
Adds Dependabot (https://docs.github.com/en/code-security/supply-chain-security/about-dependabot-version-updates) for the following packages:
- `pip` – checked daily
- `docker` – checked weekly on Mondays
- `github-actions` – checked weekly on Mondays