### PR TITLE
Change ALLOWED_HOSTS to DJANGO_ALLOWED_HOSTS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ ROOT_LOG_LEVEL=INFO
 # This is being overwritten in development to support multiple Docker dev
 # environments where you might be connecting over a local network IP address
 # instead of localhost. You should not use "*" in production.
-ALLOWED_HOSTS=".localhost,127.0.0.1,[::1]"
+DJANGO_ALLOWED_HOSTS=".localhost,127.0.0.1,[::1]"
 
 # The bind port for gunicorn.
 #

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -26,7 +26,7 @@ SECRET_KEY = os.getenv("SECRET_KEY", None)
 DEBUG = bool(strtobool(os.getenv("DEBUG", "false")))
 
 # https://docs.djangoproject.com/en/3.2/ref/settings/#std:setting-ALLOWED_HOSTS
-allowed_hosts = os.getenv("ALLOWED_HOSTS", ".localhost,127.0.0.1,[::1]")
+allowed_hosts = os.getenv("DJANGO_ALLOWED_HOSTS", ".localhost,127.0.0.1,[::1]")
 ALLOWED_HOSTS = list(map(str.strip, allowed_hosts.split(",")))
 
 # Application definition


### PR DESCRIPTION
- To match the environment variable set in the transaction service and the deployment settings, `ALLOWED_HOSTS` is now `DJANGO_ALLOWED_HOSTS`