### PR TITLE
Use Unix socket in addition to TCP to bind application

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,12 +27,11 @@ ROOT_LOG_LEVEL=INFO
 # instead of localhost. You should not use "*" in production.
 DJANGO_ALLOWED_HOSTS=".localhost,127.0.0.1,[::1]"
 
-# The bind port for gunicorn.
-#
-# Be warned that if you change this value you'll need to change 8000 in both
-# your Dockerfile and in a few spots in docker-compose.yml due to the nature of
-# how this value can be set (Docker Compose doesn't support nested ENV vars).
-GUNICORN_BIND_PORT=8000
+# Docker Nginx Volume Root
+DOCKER_NGINX_VOLUME_ROOT=/nginx
+
+# The bind socket for gunicorn
+GUNICORN_BIND_SOCKET=unix:${DOCKER_NGINX_VOLUME_ROOT}/gunicorn.socket
 
 # The port exposed to the host by the nginx image.
 NGINX_HOST_PORT=8080

--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,13 @@ ROOT_LOG_LEVEL=INFO
 # instead of localhost. You should not use "*" in production.
 DJANGO_ALLOWED_HOSTS=".localhost,127.0.0.1,[::1]"
 
+# The bind port for gunicorn.
+#
+# Be warned that if you change this value you'll need to change 8000 in both
+# your Dockerfile and in a few spots in docker-compose.yml due to the nature of
+# how this value can be set (Docker Compose doesn't support nested ENV vars).
+GUNICORN_BIND_PORT=8000
+
 # Docker Nginx Volume Root
 DOCKER_NGINX_VOLUME_ROOT=/nginx
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,18 @@
 version: "3.9"
 
+volumes:
+  nginx-shared:
+
 services:
   nginx:
     image: nginx:1.20-alpine
-    links:
-      - web:web
     env_file:
       - .env
     ports:
       - "${NGINX_HOST_PORT}:80"
     volumes:
       - ./nginx/templates:/etc/nginx/templates
+      - nginx-shared:${DOCKER_NGINX_VOLUME_ROOT}
     depends_on:
       - web
   db:
@@ -24,6 +26,8 @@ services:
   web:
     build: .
     tty: true
+    volumes:
+      - nginx-shared:${DOCKER_NGINX_VOLUME_ROOT}
     env_file:
       - .env
     depends_on:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,4 +6,4 @@ echo "==> $(date +%H:%M:%S) ==> Migrating Django models..."
 python src/manage.py migrate --noinput
 
 echo "==> $(date +%H:%M:%S) ==> Running Gunicorn..."
-exec gunicorn -c /app/src/config/gunicorn.py config.wsgi -b ${GUNICORN_BIND_SOCKET} --chdir /app/src/
+exec gunicorn -c /app/src/config/gunicorn.py config.wsgi -b ${GUNICORN_BIND_SOCKET} -b 0.0.0.0:${GUNICORN_BIND_PORT} --chdir /app/src/

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,4 +6,4 @@ echo "==> $(date +%H:%M:%S) ==> Migrating Django models..."
 python src/manage.py migrate --noinput
 
 echo "==> $(date +%H:%M:%S) ==> Running Gunicorn..."
-exec gunicorn -c /app/src/config/gunicorn.py config.wsgi -b 0.0.0.0:${GUNICORN_BIND_PORT} --chdir /app/src/
+exec gunicorn -c /app/src/config/gunicorn.py config.wsgi -b ${GUNICORN_BIND_SOCKET} --chdir /app/src/

--- a/nginx/templates/nginx.conf.template
+++ b/nginx/templates/nginx.conf.template
@@ -22,10 +22,10 @@ http {
       #
       # fail_timeout=0 means we always retry an upstream even if it failed
       # to return a good HTTP response
-      # server unix:/run/gunicorn.sock fail_timeout=0;
+      server ${GUNICORN_BIND_SOCKET} fail_timeout=0;
 
       # for a TCP configuration
-      server web:${GUNICORN_BIND_PORT} fail_timeout=0;
+      # server web:${GUNICORN_BIND_PORT} fail_timeout=0;
       keepalive 32;
     }
 


### PR DESCRIPTION
Closes #59 

- Use Unix socket to bind the application
- This avoids Nginx requiring to know the name registered of the container/service which is running the Gunicorn app