### PR TITLE
Fix lazy evaluation of ALLOWED_HOSTS and DEFAULT_RENDERER_CLASSES

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -27,7 +27,7 @@ DEBUG = bool(strtobool(os.getenv("DEBUG", "false")))
 
 # https://docs.djangoproject.com/en/3.2/ref/settings/#std:setting-ALLOWED_HOSTS
 allowed_hosts = os.getenv("DJANGO_ALLOWED_HOSTS", ".localhost,127.0.0.1,[::1]")
-ALLOWED_HOSTS = [allowed_host.strip() for allowed_host in allowed_hosts.split(",")]
+ALLOWED_HOSTS = list(allowed_host.strip() for allowed_host in allowed_hosts.split(","))
 
 # Application definition
 
@@ -36,10 +36,10 @@ default_renderer_classes = os.getenv(
 )
 REST_FRAMEWORK = {
     # https://www.django-rest-framework.org/api-guide/renderers/
-    "DEFAULT_RENDERER_CLASSES": [
+    "DEFAULT_RENDERER_CLASSES": list(
         default_renderer_class.strip()
         for default_renderer_class in default_renderer_classes.split(",")
-    ]
+    )
 }
 
 INSTALLED_APPS = [


### PR DESCRIPTION
Closes #62 

ALLOWED_HOSTS and DEFAULT_RENDERER_CLASSES are both using list comprehensions which are not evaluated lazily. Instead they are evaluated when the image is built and those environment variables do not exist.

They were changed recently in the context of this PR: https://github.com/gnosis/safe-config-service/pull/58

