### PR TITLE
Format JSON response keys to camel case

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,8 +69,8 @@ GUNICORN_WEB_RELOAD=false
 
 # REST Framework Default Renderers (comma seperated list)
 # https://www.django-rest-framework.org/api-guide/renderers/
-#REST_DEFAULT_RENDERER_CLASSES="rest_framework.renderers.JSONRenderer,rest_framework.renderers.BrowsableAPIRenderer"
-REST_DEFAULT_RENDERER_CLASSES="rest_framework.renderers.JSONRenderer"
+#REST_DEFAULT_RENDERER_CLASSES="djangorestframework_camel_case.render.CamelCaseJSONRenderer,rest_framework.renderers.BrowsableAPIRenderer"
+REST_DEFAULT_RENDERER_CLASSES="djangorestframework_camel_case.render.CamelCaseJSONRenderer"
 
 # What CPU and memory constraints will be added to your services? When left at
 # 0, they will happily use as much as needed.

--- a/.env.example
+++ b/.env.example
@@ -67,11 +67,6 @@ POSTGRES_PORT=5432
 # This setting is intended for development. It will cause workers to be restarted whenever application code changes.
 GUNICORN_WEB_RELOAD=false
 
-# REST Framework Default Renderers (comma seperated list)
-# https://www.django-rest-framework.org/api-guide/renderers/
-#REST_DEFAULT_RENDERER_CLASSES="djangorestframework_camel_case.render.CamelCaseJSONRenderer,rest_framework.renderers.BrowsableAPIRenderer"
-REST_DEFAULT_RENDERER_CLASSES="djangorestframework_camel_case.render.CamelCaseJSONRenderer"
-
 # What CPU and memory constraints will be added to your services? When left at
 # 0, they will happily use as much as needed.
 #DOCKER_POSTGRES_CPUS=0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Django==3.2.3
 djangorestframework==3.12.4
+djangorestframework-camel-case==1.2.0
 gunicorn==20.1.0
 psycopg2-binary==2.8.6

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -31,15 +31,10 @@ ALLOWED_HOSTS = [allowed_host.strip() for allowed_host in allowed_hosts.split(",
 
 # Application definition
 
-default_renderer_classes = os.getenv(
-    "REST_DEFAULT_RENDERER_CLASSES",
-    "djangorestframework_camel_case.render.CamelCaseJSONRenderer",
-)
 REST_FRAMEWORK = {
     # https://www.django-rest-framework.org/api-guide/renderers/
     "DEFAULT_RENDERER_CLASSES": [
-        default_renderer_class.strip()
-        for default_renderer_class in default_renderer_classes.split(",")
+        "djangorestframework_camel_case.render.CamelCaseJSONRenderer",
     ]
 }
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -32,7 +32,8 @@ ALLOWED_HOSTS = [allowed_host.strip() for allowed_host in allowed_hosts.split(",
 # Application definition
 
 default_renderer_classes = os.getenv(
-    "REST_DEFAULT_RENDERER_CLASSES", "rest_framework.renderers.JSONRenderer"
+    "REST_DEFAULT_RENDERER_CLASSES",
+    "djangorestframework_camel_case.render.CamelCaseJSONRenderer",
 )
 REST_FRAMEWORK = {
     # https://www.django-rest-framework.org/api-guide/renderers/

--- a/src/safe_apps/tests/test_views.py
+++ b/src/safe_apps/tests/test_views.py
@@ -14,6 +14,28 @@ class EmptySafeAppsListViewTests(APITestCase):
         self.assertEqual(response.data, [])
 
 
+class JsonPayloadFormatViewTests(APITestCase):
+    def test_json_payload_format(self):
+        safe_app = SafeAppFactory.create()
+
+        json_response = [
+            {
+                "url": safe_app.url,
+                "name": safe_app.name,
+                "iconUrl": safe_app.icon_url,
+                "description": safe_app.description,
+                "networks": safe_app.networks,
+                "provider": None,
+            }
+        ]
+        url = reverse("v1:safe-apps")
+
+        response = self.client.get(path=url, data=None, format="json")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), json_response)
+
+
 class FilterSafeAppListViewTests(APITestCase):
     def test_all_safes_returned(self):
         (safe_app_1, safe_app_2, safe_app_3) = SafeAppFactory.create_batch(3)

--- a/src/safe_apps/tests/test_views.py
+++ b/src/safe_apps/tests/test_views.py
@@ -1,5 +1,3 @@
-import json
-
 from django.urls import reverse
 from rest_framework.test import APITestCase
 
@@ -13,7 +11,7 @@ class EmptySafeAppsListViewTests(APITestCase):
         response = self.client.get(path=url, data=None, format="json")
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), [])
+        self.assertEqual(response.data, [])
 
 
 class FilterSafeAppListViewTests(APITestCase):
@@ -23,7 +21,7 @@ class FilterSafeAppListViewTests(APITestCase):
             {
                 "url": safe_app_1.url,
                 "name": safe_app_1.name,
-                "iconUrl": safe_app_1.icon_url,
+                "icon_url": safe_app_1.icon_url,
                 "description": safe_app_1.description,
                 "networks": safe_app_1.networks,
                 "provider": None,
@@ -31,7 +29,7 @@ class FilterSafeAppListViewTests(APITestCase):
             {
                 "url": safe_app_2.url,
                 "name": safe_app_2.name,
-                "iconUrl": safe_app_2.icon_url,
+                "icon_url": safe_app_2.icon_url,
                 "description": safe_app_2.description,
                 "networks": safe_app_2.networks,
                 "provider": None,
@@ -39,7 +37,7 @@ class FilterSafeAppListViewTests(APITestCase):
             {
                 "url": safe_app_3.url,
                 "name": safe_app_3.name,
-                "iconUrl": safe_app_3.icon_url,
+                "icon_url": safe_app_3.icon_url,
                 "description": safe_app_3.description,
                 "networks": safe_app_3.networks,
                 "provider": None,
@@ -50,7 +48,7 @@ class FilterSafeAppListViewTests(APITestCase):
         response = self.client.get(path=url, data=None, format="json")
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), json_response)
+        self.assertEqual(response.data, json_response)
 
     def test_all_apps_returned_on_empty_network_value(self):
         (safe_app_1, safe_app_2, safe_app_3) = SafeAppFactory.create_batch(3)
@@ -58,7 +56,7 @@ class FilterSafeAppListViewTests(APITestCase):
             {
                 "url": safe_app_1.url,
                 "name": safe_app_1.name,
-                "iconUrl": safe_app_1.icon_url,
+                "icon_url": safe_app_1.icon_url,
                 "description": safe_app_1.description,
                 "networks": safe_app_1.networks,
                 "provider": None,
@@ -66,7 +64,7 @@ class FilterSafeAppListViewTests(APITestCase):
             {
                 "url": safe_app_2.url,
                 "name": safe_app_2.name,
-                "iconUrl": safe_app_2.icon_url,
+                "icon_url": safe_app_2.icon_url,
                 "description": safe_app_2.description,
                 "networks": safe_app_2.networks,
                 "provider": None,
@@ -74,7 +72,7 @@ class FilterSafeAppListViewTests(APITestCase):
             {
                 "url": safe_app_3.url,
                 "name": safe_app_3.name,
-                "iconUrl": safe_app_3.icon_url,
+                "icon_url": safe_app_3.icon_url,
                 "description": safe_app_3.description,
                 "networks": safe_app_3.networks,
                 "provider": None,
@@ -85,7 +83,7 @@ class FilterSafeAppListViewTests(APITestCase):
         response = self.client.get(path=url, data=None, format="json")
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), json_response)
+        self.assertEqual(response.data, json_response)
 
     def test_apps_returned_on_filtered_network(self):
         SafeAppFactory.create_batch(3, networks=[10])
@@ -95,7 +93,7 @@ class FilterSafeAppListViewTests(APITestCase):
             {
                 "url": safe_app_4.url,
                 "name": safe_app_4.name,
-                "iconUrl": safe_app_4.icon_url,
+                "icon_url": safe_app_4.icon_url,
                 "description": safe_app_4.description,
                 "networks": safe_app_4.networks,
                 "provider": None,
@@ -103,7 +101,7 @@ class FilterSafeAppListViewTests(APITestCase):
             {
                 "url": safe_app_5.url,
                 "name": safe_app_5.name,
-                "iconUrl": safe_app_5.icon_url,
+                "icon_url": safe_app_5.icon_url,
                 "description": safe_app_5.description,
                 "networks": safe_app_5.networks,
                 "provider": None,
@@ -114,7 +112,7 @@ class FilterSafeAppListViewTests(APITestCase):
         response = self.client.get(path=url, data=None, format="json")
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), json_response)
+        self.assertEqual(response.data, json_response)
 
     def test_apps_returned_on_unexisting_network(self):
         SafeAppFactory.create_batch(3, networks=[12])
@@ -124,7 +122,7 @@ class FilterSafeAppListViewTests(APITestCase):
         response = self.client.get(path=url, data=None, format="json")
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), json_response)
+        self.assertEqual(response.data, json_response)
 
     def test_apps_returned_on_same_key_pair(self):
         safe_app_1 = SafeAppFactory.create(networks=[1])
@@ -133,7 +131,7 @@ class FilterSafeAppListViewTests(APITestCase):
             {
                 "url": safe_app_1.url,
                 "name": safe_app_1.name,
-                "iconUrl": safe_app_1.icon_url,
+                "icon_url": safe_app_1.icon_url,
                 "description": safe_app_1.description,
                 "networks": safe_app_1.networks,
                 "provider": None,
@@ -144,7 +142,7 @@ class FilterSafeAppListViewTests(APITestCase):
         response = self.client.get(path=url, data=None, format="json")
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), json_response)
+        self.assertEqual(response.data, json_response)
 
 
 class ProviderInfoTests(APITestCase):
@@ -156,7 +154,7 @@ class ProviderInfoTests(APITestCase):
             {
                 "url": safe_app.url,
                 "name": safe_app.name,
-                "iconUrl": safe_app.icon_url,
+                "icon_url": safe_app.icon_url,
                 "description": safe_app.description,
                 "networks": safe_app.networks,
                 "provider": {"name": provider.name, "url": provider.url},
@@ -167,7 +165,7 @@ class ProviderInfoTests(APITestCase):
         response = self.client.get(path=url, data=None, format="json")
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), json_response)
+        self.assertEqual(response.data, json_response)
 
     def test_provider_not_returned_in_response(self):
         safe_app = SafeAppFactory.create()
@@ -176,7 +174,7 @@ class ProviderInfoTests(APITestCase):
             {
                 "url": safe_app.url,
                 "name": safe_app.name,
-                "iconUrl": safe_app.icon_url,
+                "icon_url": safe_app.icon_url,
                 "description": safe_app.description,
                 "networks": safe_app.networks,
                 "provider": None,
@@ -187,7 +185,7 @@ class ProviderInfoTests(APITestCase):
         response = self.client.get(path=url, data=None, format="json")
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), json_response)
+        self.assertEqual(response.data, json_response)
 
 
 class CacheSafeAppTests(APITestCase):
@@ -198,7 +196,7 @@ class CacheSafeAppTests(APITestCase):
             {
                 "url": safe_app_1.url,
                 "name": safe_app_1.name,
-                "iconUrl": safe_app_1.icon_url,
+                "icon_url": safe_app_1.icon_url,
                 "description": safe_app_1.description,
                 "networks": safe_app_1.networks,
                 "provider": None,
@@ -213,4 +211,4 @@ class CacheSafeAppTests(APITestCase):
         self.assertEqual(response.status_code, 200)
         # Cache-Control should be 10 minutes (60 * 10)
         self.assertEqual(cache_control, "max-age=600")
-        self.assertEqual(json.loads(response.content), json_response)
+        self.assertEqual(response.data, json_response)

--- a/src/safe_apps/tests/test_views.py
+++ b/src/safe_apps/tests/test_views.py
@@ -23,7 +23,7 @@ class FilterSafeAppListViewTests(APITestCase):
             {
                 "url": safe_app_1.url,
                 "name": safe_app_1.name,
-                "icon_url": safe_app_1.icon_url,
+                "iconUrl": safe_app_1.icon_url,
                 "description": safe_app_1.description,
                 "networks": safe_app_1.networks,
                 "provider": None,
@@ -31,7 +31,7 @@ class FilterSafeAppListViewTests(APITestCase):
             {
                 "url": safe_app_2.url,
                 "name": safe_app_2.name,
-                "icon_url": safe_app_2.icon_url,
+                "iconUrl": safe_app_2.icon_url,
                 "description": safe_app_2.description,
                 "networks": safe_app_2.networks,
                 "provider": None,
@@ -39,7 +39,7 @@ class FilterSafeAppListViewTests(APITestCase):
             {
                 "url": safe_app_3.url,
                 "name": safe_app_3.name,
-                "icon_url": safe_app_3.icon_url,
+                "iconUrl": safe_app_3.icon_url,
                 "description": safe_app_3.description,
                 "networks": safe_app_3.networks,
                 "provider": None,
@@ -58,7 +58,7 @@ class FilterSafeAppListViewTests(APITestCase):
             {
                 "url": safe_app_1.url,
                 "name": safe_app_1.name,
-                "icon_url": safe_app_1.icon_url,
+                "iconUrl": safe_app_1.icon_url,
                 "description": safe_app_1.description,
                 "networks": safe_app_1.networks,
                 "provider": None,
@@ -66,7 +66,7 @@ class FilterSafeAppListViewTests(APITestCase):
             {
                 "url": safe_app_2.url,
                 "name": safe_app_2.name,
-                "icon_url": safe_app_2.icon_url,
+                "iconUrl": safe_app_2.icon_url,
                 "description": safe_app_2.description,
                 "networks": safe_app_2.networks,
                 "provider": None,
@@ -74,7 +74,7 @@ class FilterSafeAppListViewTests(APITestCase):
             {
                 "url": safe_app_3.url,
                 "name": safe_app_3.name,
-                "icon_url": safe_app_3.icon_url,
+                "iconUrl": safe_app_3.icon_url,
                 "description": safe_app_3.description,
                 "networks": safe_app_3.networks,
                 "provider": None,
@@ -95,7 +95,7 @@ class FilterSafeAppListViewTests(APITestCase):
             {
                 "url": safe_app_4.url,
                 "name": safe_app_4.name,
-                "icon_url": safe_app_4.icon_url,
+                "iconUrl": safe_app_4.icon_url,
                 "description": safe_app_4.description,
                 "networks": safe_app_4.networks,
                 "provider": None,
@@ -103,7 +103,7 @@ class FilterSafeAppListViewTests(APITestCase):
             {
                 "url": safe_app_5.url,
                 "name": safe_app_5.name,
-                "icon_url": safe_app_5.icon_url,
+                "iconUrl": safe_app_5.icon_url,
                 "description": safe_app_5.description,
                 "networks": safe_app_5.networks,
                 "provider": None,
@@ -133,7 +133,7 @@ class FilterSafeAppListViewTests(APITestCase):
             {
                 "url": safe_app_1.url,
                 "name": safe_app_1.name,
-                "icon_url": safe_app_1.icon_url,
+                "iconUrl": safe_app_1.icon_url,
                 "description": safe_app_1.description,
                 "networks": safe_app_1.networks,
                 "provider": None,
@@ -156,7 +156,7 @@ class ProviderInfoTests(APITestCase):
             {
                 "url": safe_app.url,
                 "name": safe_app.name,
-                "icon_url": safe_app.icon_url,
+                "iconUrl": safe_app.icon_url,
                 "description": safe_app.description,
                 "networks": safe_app.networks,
                 "provider": {"name": provider.name, "url": provider.url},
@@ -176,7 +176,7 @@ class ProviderInfoTests(APITestCase):
             {
                 "url": safe_app.url,
                 "name": safe_app.name,
-                "icon_url": safe_app.icon_url,
+                "iconUrl": safe_app.icon_url,
                 "description": safe_app.description,
                 "networks": safe_app.networks,
                 "provider": None,
@@ -198,7 +198,7 @@ class CacheSafeAppTests(APITestCase):
             {
                 "url": safe_app_1.url,
                 "name": safe_app_1.name,
-                "icon_url": safe_app_1.icon_url,
+                "iconUrl": safe_app_1.icon_url,
                 "description": safe_app_1.description,
                 "networks": safe_app_1.networks,
                 "provider": None,


### PR DESCRIPTION
Closes #64 

- JSON keys in response payloads are now in camel case
- Add `djangorestframework-camel-case` – this renderer class is responsible for converting the keys to camel case (it is now the default renderer)


### Open Questions:

- Would this dependency be ok or shall we go with an internal solution? I saw already this dependency being used here so I guess we can continue using it: https://github.com/gnosis/safe-transaction-service/blob/cda755631cadbe03f2cc5e792d80f721212556c8/requirements.txt#L18