### PR TITLE
Add Swagger

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,5 +2,6 @@
 omit =
     src/config/asgi.py
     src/config/gunicorn.py
+    src/config/swagger_info.py
     src/config/wsgi.py
     src/manage.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Django==3.2.3
 djangorestframework==3.12.4
 djangorestframework-camel-case==1.2.0
+drf-yasg[validation]==1.20.0
 gunicorn==20.1.0
 psycopg2-binary==2.8.6

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -47,6 +47,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "rest_framework",
+    "drf_yasg",
 ]
 
 MIDDLEWARE = [
@@ -175,3 +176,7 @@ STATIC_URL = "/static/"
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+SWAGGER_SETTINGS = {
+    "DEFAULT_INFO": "config.swagger_info.SAFE_CONFIG_SERVICE_SWAGGER_INFO"
+}

--- a/src/config/swagger_info.py
+++ b/src/config/swagger_info.py
@@ -1,0 +1,9 @@
+from drf_yasg import openapi
+
+SAFE_CONFIG_SERVICE_SWAGGER_INFO = openapi.Info(
+    title="Gnosis Safe Config Service API",
+    default_version="v1",
+    description="Service that provides configuration information in the context of the Safe clients environment",
+    contact=openapi.Contact(email="safe@gnosis.io"),
+    license=openapi.License(name="MIT License"),
+)

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -20,7 +20,7 @@ urlpatterns = [
         name="schema-json",
     ),
     re_path(
-        r"^swagger/$",
+        r"^$",
         schema_view.with_ui("swagger", cache_timeout=0),
         name="schema-swagger-ui",
     ),

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -1,9 +1,27 @@
 from django.contrib import admin
 from django.http import HttpResponse
-from django.urls import include, path
+from django.urls import include, path, re_path
+from drf_yasg.views import get_schema_view
+from rest_framework import permissions
+
+schema_view = get_schema_view(
+    validators=["flex", "ssv"],
+    public=True,
+    permission_classes=(permissions.AllowAny,),
+)
 
 urlpatterns = [
     path("api/v1/", include("safe_apps.urls", namespace="v1")),
     path("admin/", admin.site.urls),
     path("check/", lambda request: HttpResponse("Ok"), name="check"),
+    re_path(
+        r"^swagger(?P<format>\.json|\.yaml)$",
+        schema_view.without_ui(cache_timeout=0),
+        name="schema-json",
+    ),
+    re_path(
+        r"^swagger/$",
+        schema_view.with_ui("swagger", cache_timeout=0),
+        name="schema-swagger-ui",
+    ),
 ]

--- a/src/safe_apps/views.py
+++ b/src/safe_apps/views.py
@@ -1,5 +1,7 @@
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework.generics import ListAPIView
 
 from .models import SafeApp
@@ -9,8 +11,20 @@ from .serializers import SafeAppsResponseSerializer
 class SafeAppsListView(ListAPIView):
     serializer_class = SafeAppsResponseSerializer
 
+    _swagger_network_id_param = openapi.Parameter(
+        "network_id",
+        openapi.IN_QUERY,
+        description="Used to filter Safe Apps that are available on `network_id`",
+        type=openapi.TYPE_INTEGER,
+    )
+
     @method_decorator(cache_page(60 * 10, cache="safe-apps"))  # Cache 10 minutes
+    @swagger_auto_schema(manual_parameters=[_swagger_network_id_param])
     def get(self, request, *args, **kwargs):
+        """
+        Returns a collection of Safe Apps (across different networks).
+        Each Safe App can optionally include the information about the `Provider`
+        """
         return super().get(self, request, *args, **kwargs)
 
     def get_queryset(self):


### PR DESCRIPTION
Closes #73 

- Adds Swagger specification page to the project with `drf-yasg`
- Provide default Swagger Info in Django Settings file (info under `swagger_info.py`)