### PR TITLE
Serve static files with Nginx

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,6 +2,11 @@
 
 set -euo pipefail
 
+echo "==> $(date +%H:%M:%S) ==> Collecting static files..."
+python src/manage.py collectstatic --noinput
+rm -rf ${DOCKER_NGINX_VOLUME_ROOT}/*
+cp -r staticfiles/ ${DOCKER_NGINX_VOLUME_ROOT}/
+
 echo "==> $(date +%H:%M:%S) ==> Migrating Django models..."
 python src/manage.py migrate --noinput
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -171,6 +171,8 @@ USE_TZ = True
 
 STATIC_URL = "/static/"
 
+STATIC_ROOT = "staticfiles"
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
 


### PR DESCRIPTION
Closes #75 

- Collect static files when the web image is deployed with `manage.py collectstatic`
- Copy collected files folder (`staticfiles/`) to `${DOCKER_NGINX_VOLUME_ROOT}`