### PR TITLE
Add CORS headers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Django==3.2.3
+django-cors-headers==3.7.0
 djangorestframework==3.12.4
 djangorestframework-camel-case==1.2.0
 drf-yasg[validation]==1.20.0

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -39,6 +39,7 @@ REST_FRAMEWORK = {
 }
 
 INSTALLED_APPS = [
+    "corsheaders",
     "safe_apps.apps.AppsConfig",
     "django.contrib.admin",
     "django.contrib.auth",
@@ -52,6 +53,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "config.middleware.LoggingMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -182,3 +184,6 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 SWAGGER_SETTINGS = {
     "DEFAULT_INFO": "config.swagger_info.SAFE_CONFIG_SERVICE_SWAGGER_INFO"
 }
+
+CORS_ALLOW_ALL_ORIGINS = True
+CORS_URLS_REGEX = r"^/api/.*$"


### PR DESCRIPTION
Closes #79 

- Adds CORS headers
- Allow any origin to request the resources under `^/api/.*$`