### PR TITLE
Bump nginx from 1.20 to 1.20.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ volumes:
 
 services:
   nginx:
-    image: nginx:1.20-alpine
+    image: nginx:1.20.1-alpine
     env_file:
       - .env
     ports:


### PR DESCRIPTION
Updates Nginx image in `docker-compose` from 1.20 to 1.20.1

Changelog: https://nginx.org/en/CHANGES-1.20