### PR TITLE
Bump postgres from 13 to 13.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     depends_on:
       - web
   db:
-    image: postgres:13-alpine
+    image: postgres:13.3-alpine
     env_file:
       - .env
     volumes:


### PR DESCRIPTION
Updates Postgres image in docker-compose from version 13 to 13.3

Changelog: https://www.postgresql.org/docs/release/13.3/