### PR TITLE
Reverse /safe-apps resolution to safe-apps:list

### DIFF
--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -11,7 +11,7 @@ schema_view = get_schema_view(
 )
 
 urlpatterns = [
-    path("api/v1/", include("safe_apps.urls", namespace="v1")),
+    path("api/v1/", include("safe_apps.urls", namespace="safe-apps")),
     path("api/v1/", include("chains.urls", namespace="chains")),
     path("admin/", admin.site.urls),
     path("check/", lambda request: HttpResponse("Ok"), name="check"),

--- a/src/safe_apps/tests/test_views.py
+++ b/src/safe_apps/tests/test_views.py
@@ -6,7 +6,7 @@ from .factories import ProviderFactory, SafeAppFactory
 
 class EmptySafeAppsListViewTests(APITestCase):
     def test_empty_set(self):
-        url = reverse("v1:safe-apps")
+        url = reverse("safe-apps:list")
 
         response = self.client.get(path=url, data=None, format="json")
 
@@ -28,7 +28,7 @@ class JsonPayloadFormatViewTests(APITestCase):
                 "provider": None,
             }
         ]
-        url = reverse("v1:safe-apps")
+        url = reverse("safe-apps:list")
 
         response = self.client.get(path=url, data=None, format="json")
 
@@ -65,7 +65,7 @@ class FilterSafeAppListViewTests(APITestCase):
                 "provider": None,
             },
         ]
-        url = reverse("v1:safe-apps")
+        url = reverse("safe-apps:list")
 
         response = self.client.get(path=url, data=None, format="json")
 
@@ -100,7 +100,7 @@ class FilterSafeAppListViewTests(APITestCase):
                 "provider": None,
             },
         ]
-        url = reverse("v1:safe-apps") + f'{"?chainId="}'
+        url = reverse("safe-apps:list") + f'{"?chainId="}'
 
         response = self.client.get(path=url, data=None, format="json")
 
@@ -129,7 +129,7 @@ class FilterSafeAppListViewTests(APITestCase):
                 "provider": None,
             },
         ]
-        url = reverse("v1:safe-apps") + f'{"?chainId=1"}'
+        url = reverse("safe-apps:list") + f'{"?chainId=1"}'
 
         response = self.client.get(path=url, data=None, format="json")
 
@@ -139,7 +139,7 @@ class FilterSafeAppListViewTests(APITestCase):
     def test_apps_returned_on_unexisting_chain(self):
         SafeAppFactory.create_batch(3, chain_ids=[12])
         json_response = []
-        url = reverse("v1:safe-apps") + f'{"?chainId=10"}'
+        url = reverse("safe-apps:list") + f'{"?chainId=10"}'
 
         response = self.client.get(path=url, data=None, format="json")
 
@@ -159,7 +159,7 @@ class FilterSafeAppListViewTests(APITestCase):
                 "provider": None,
             }
         ]
-        url = reverse("v1:safe-apps") + f'{"?chainId=2&chainId=1"}'
+        url = reverse("safe-apps:list") + f'{"?chainId=2&chainId=1"}'
 
         response = self.client.get(path=url, data=None, format="json")
 
@@ -182,7 +182,7 @@ class ProviderInfoTests(APITestCase):
                 "provider": {"name": provider.name, "url": provider.url},
             }
         ]
-        url = reverse("v1:safe-apps")
+        url = reverse("safe-apps:list")
 
         response = self.client.get(path=url, data=None, format="json")
 
@@ -202,7 +202,7 @@ class ProviderInfoTests(APITestCase):
                 "provider": None,
             }
         ]
-        url = reverse("v1:safe-apps")
+        url = reverse("safe-apps:list")
 
         response = self.client.get(path=url, data=None, format="json")
 
@@ -224,7 +224,7 @@ class CacheSafeAppTests(APITestCase):
                 "provider": None,
             }
         ]
-        url = reverse("v1:safe-apps")
+        url = reverse("safe-apps:list")
 
         response = self.client.get(path=url, data=None, format="json")
 

--- a/src/safe_apps/urls.py
+++ b/src/safe_apps/urls.py
@@ -5,5 +5,5 @@ from .views import SafeAppsListView
 app_name = "apps"
 
 urlpatterns = [
-    path("safe-apps/", SafeAppsListView.as_view(), name="safe-apps"),
+    path("safe-apps/", SafeAppsListView.as_view(), name="list"),
 ]


### PR DESCRIPTION
Closes #89 

- Change `/api/v1/safe-apps` reverse resolution from `v1:safe-apps` to `safe-apps:list`