### PR TITLE
Remove unecessary swagger annotation

### DIFF
--- a/src/chains/views.py
+++ b/src/chains/views.py
@@ -1,4 +1,3 @@
-from drf_yasg.utils import swagger_auto_schema
 from rest_framework.generics import ListAPIView
 from rest_framework.pagination import LimitOffsetPagination
 
@@ -11,10 +10,6 @@ class ChainsListView(ListAPIView):
     pagination_class = LimitOffsetPagination
     pagination_class.max_limit = 10
     pagination_class.default_limit = 10
-
-    @swagger_auto_schema()
-    def get(self, request, *args, **kwargs):
-        return super().get(self, request, *args, **kwargs)
 
     def get_queryset(self):
         return Chain.objects.all()


### PR DESCRIPTION
- Remove unused `@swagger_auto_schema` annotation from `ChainsListView`