### PR TITLE
Add /chains/<id> endpoint

### DIFF
--- a/src/chains/tests/factories.py
+++ b/src/chains/tests/factories.py
@@ -8,7 +8,7 @@ class ChainFactory(DjangoModelFactory):
     class Meta:
         model = Chain
 
-    id = factory.Faker("pystr_format", string_format="#{{random_int}}")
+    id = factory.Faker("pyint")
     name = factory.Faker("company")
     rpc_url = factory.Faker("url")
     block_explorer_url = factory.Faker("url")

--- a/src/chains/urls.py
+++ b/src/chains/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
 
-from chains.views import ChainsListView
+from chains.views import ChainsDetailView, ChainsListView
 
 app_name = "chains"
 
 urlpatterns = [
     path("chains/", ChainsListView.as_view(), name="list"),
+    path("chains/<pk>", ChainsDetailView.as_view(), name="detail"),
 ]

--- a/src/chains/views.py
+++ b/src/chains/views.py
@@ -1,4 +1,4 @@
-from rest_framework.generics import ListAPIView
+from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.pagination import LimitOffsetPagination
 
 from .models import Chain
@@ -10,6 +10,9 @@ class ChainsListView(ListAPIView):
     pagination_class = LimitOffsetPagination
     pagination_class.max_limit = 10
     pagination_class.default_limit = 10
+    queryset = Chain.objects.all()
 
-    def get_queryset(self):
-        return Chain.objects.all()
+
+class ChainsDetailView(RetrieveAPIView):
+    serializer_class = ChainSerializer
+    queryset = Chain.objects.all()


### PR DESCRIPTION
- Adds `/chains/<id>` – this endpoint returns the chain with the `id` set in the path. `404` is returned if the chain was not found
- Use `response.data` in tests to avoid testing the json format – there is already a test validating the format of the payload – `ChainJsonPayloadFormatViewTests.test_json_payload_format`
- `ChainFactory` now returns a `pyint`. This matches better was is stored by the `Chain` model