### PR TITLE
Use nested namespaces for versioning

### DIFF
--- a/src/chains/tests/test_views.py
+++ b/src/chains/tests/test_views.py
@@ -6,7 +6,7 @@ from .factories import ChainFactory
 
 class EmptyChainsListViewTests(APITestCase):
     def test_empty_chains(self):
-        url = reverse("chains:list")
+        url = reverse("v1:chains:list")
         json_response = {"count": 0, "next": None, "previous": None, "results": []}
 
         response = self.client.get(path=url, data=None, format="json")
@@ -37,7 +37,7 @@ class ChainJsonPayloadFormatViewTests(APITestCase):
                 }
             ],
         }
-        url = reverse("chains:list")
+        url = reverse("v1:chains:list")
 
         response = self.client.get(path=url, data=None, format="json")
 
@@ -48,7 +48,7 @@ class ChainJsonPayloadFormatViewTests(APITestCase):
 class ChainPaginationViewTests(APITestCase):
     def test_pagination_next_page(self):
         ChainFactory.create_batch(11)
-        url = reverse("chains:list")
+        url = reverse("v1:chains:list")
 
         response = self.client.get(path=url, data=None, format="json")
 
@@ -66,7 +66,7 @@ class ChainPaginationViewTests(APITestCase):
     def test_request_more_than_max_limit_should_return_max_limit(self):
         ChainFactory.create_batch(11)
         # requesting limit > max_limit
-        url = reverse("chains:list") + f'{"?limit=11"}'
+        url = reverse("v1:chains:list") + f'{"?limit=11"}'
 
         response = self.client.get(path=url, data=None, format="json")
 
@@ -84,7 +84,7 @@ class ChainPaginationViewTests(APITestCase):
     def test_offset_greater_than_count(self):
         ChainFactory.create_batch(11)
         # requesting offset of number of chains
-        url = reverse("chains:list") + f'{"?offset=11"}'
+        url = reverse("v1:chains:list") + f'{"?offset=11"}'
 
         response = self.client.get(path=url, data=None, format="json")
 
@@ -102,7 +102,7 @@ class ChainPaginationViewTests(APITestCase):
 class ChainDetailViewTests(APITestCase):
     def test_json_payload_format(self):
         chain = ChainFactory.create(id=1)
-        url = reverse("chains:detail", args=[1])
+        url = reverse("v1:chains:detail", args=[1])
         json_response = {
             "chainId": str(chain.id),
             "chainName": chain.name,
@@ -123,7 +123,7 @@ class ChainDetailViewTests(APITestCase):
 
     def test_no_match(self):
         ChainFactory.create(id=1)
-        url = reverse("chains:detail", args=[2])
+        url = reverse("v1:chains:detail", args=[2])
 
         response = self.client.get(path=url, data=None, format="json")
 
@@ -131,7 +131,7 @@ class ChainDetailViewTests(APITestCase):
 
     def test_match(self):
         chain = ChainFactory.create(id=1)
-        url = reverse("chains:detail", args=[1])
+        url = reverse("v1:chains:detail", args=[1])
         json_response = {
             "chain_id": str(chain.id),
             "chain_name": chain.name,

--- a/src/chains/urls.py
+++ b/src/chains/urls.py
@@ -5,6 +5,6 @@ from chains.views import ChainsDetailView, ChainsListView
 app_name = "chains"
 
 urlpatterns = [
-    path("chains/", ChainsListView.as_view(), name="list"),
-    path("chains/<pk>", ChainsDetailView.as_view(), name="detail"),
+    path("", ChainsListView.as_view(), name="list"),
+    path("<pk>", ChainsDetailView.as_view(), name="detail"),
 ]

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -35,7 +35,8 @@ REST_FRAMEWORK = {
     # https://www.django-rest-framework.org/api-guide/renderers/
     "DEFAULT_RENDERER_CLASSES": [
         "djangorestframework_camel_case.render.CamelCaseJSONRenderer",
-    ]
+    ],
+    "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.NamespaceVersioning",
 }
 
 INSTALLED_APPS = [

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -10,9 +10,13 @@ schema_view = get_schema_view(
     permission_classes=(permissions.AllowAny,),
 )
 
+urlpatterns_v1 = [
+    path("safe-apps/", include("safe_apps.urls", namespace="safe-apps")),
+    path("chains/", include("chains.urls", namespace="chains")),
+]
+
 urlpatterns = [
-    path("api/v1/", include("safe_apps.urls", namespace="safe-apps")),
-    path("api/v1/", include("chains.urls", namespace="chains")),
+    path("api/v1/", include((urlpatterns_v1, "v1"), namespace="v1")),
     path("admin/", admin.site.urls),
     path("check/", lambda request: HttpResponse("Ok"), name="check"),
     re_path(

--- a/src/safe_apps/tests/test_views.py
+++ b/src/safe_apps/tests/test_views.py
@@ -6,7 +6,7 @@ from .factories import ProviderFactory, SafeAppFactory
 
 class EmptySafeAppsListViewTests(APITestCase):
     def test_empty_set(self):
-        url = reverse("safe-apps:list")
+        url = reverse("v1:safe-apps:list")
 
         response = self.client.get(path=url, data=None, format="json")
 
@@ -28,7 +28,7 @@ class JsonPayloadFormatViewTests(APITestCase):
                 "provider": None,
             }
         ]
-        url = reverse("safe-apps:list")
+        url = reverse("v1:safe-apps:list")
 
         response = self.client.get(path=url, data=None, format="json")
 
@@ -65,7 +65,7 @@ class FilterSafeAppListViewTests(APITestCase):
                 "provider": None,
             },
         ]
-        url = reverse("safe-apps:list")
+        url = reverse("v1:safe-apps:list")
 
         response = self.client.get(path=url, data=None, format="json")
 
@@ -100,7 +100,7 @@ class FilterSafeAppListViewTests(APITestCase):
                 "provider": None,
             },
         ]
-        url = reverse("safe-apps:list") + f'{"?chainId="}'
+        url = reverse("v1:safe-apps:list") + f'{"?chainId="}'
 
         response = self.client.get(path=url, data=None, format="json")
 
@@ -129,7 +129,7 @@ class FilterSafeAppListViewTests(APITestCase):
                 "provider": None,
             },
         ]
-        url = reverse("safe-apps:list") + f'{"?chainId=1"}'
+        url = reverse("v1:safe-apps:list") + f'{"?chainId=1"}'
 
         response = self.client.get(path=url, data=None, format="json")
 
@@ -139,7 +139,7 @@ class FilterSafeAppListViewTests(APITestCase):
     def test_apps_returned_on_unexisting_chain(self):
         SafeAppFactory.create_batch(3, chain_ids=[12])
         json_response = []
-        url = reverse("safe-apps:list") + f'{"?chainId=10"}'
+        url = reverse("v1:safe-apps:list") + f'{"?chainId=10"}'
 
         response = self.client.get(path=url, data=None, format="json")
 
@@ -159,7 +159,7 @@ class FilterSafeAppListViewTests(APITestCase):
                 "provider": None,
             }
         ]
-        url = reverse("safe-apps:list") + f'{"?chainId=2&chainId=1"}'
+        url = reverse("v1:safe-apps:list") + f'{"?chainId=2&chainId=1"}'
 
         response = self.client.get(path=url, data=None, format="json")
 
@@ -182,7 +182,7 @@ class ProviderInfoTests(APITestCase):
                 "provider": {"name": provider.name, "url": provider.url},
             }
         ]
-        url = reverse("safe-apps:list")
+        url = reverse("v1:safe-apps:list")
 
         response = self.client.get(path=url, data=None, format="json")
 
@@ -202,7 +202,7 @@ class ProviderInfoTests(APITestCase):
                 "provider": None,
             }
         ]
-        url = reverse("safe-apps:list")
+        url = reverse("v1:safe-apps:list")
 
         response = self.client.get(path=url, data=None, format="json")
 
@@ -224,7 +224,7 @@ class CacheSafeAppTests(APITestCase):
                 "provider": None,
             }
         ]
-        url = reverse("safe-apps:list")
+        url = reverse("v1:safe-apps:list")
 
         response = self.client.get(path=url, data=None, format="json")
 

--- a/src/safe_apps/urls.py
+++ b/src/safe_apps/urls.py
@@ -5,5 +5,5 @@ from .views import SafeAppsListView
 app_name = "apps"
 
 urlpatterns = [
-    path("safe-apps/", SafeAppsListView.as_view(), name="list"),
+    path("", SafeAppsListView.as_view(), name="list"),
 ]


### PR DESCRIPTION
Closes #107 

- Url paths that require versioning are now under a nested namespace: `v1`
- This means that `chains` and `safe-apps` apps are now under `v1:chains` and `v1:safe-apps` respectively 
- Enable request versioning with `rest_framework.versioning.NamespaceVersioning`