### PR TITLE
Add trailing slash to chains/<id>/ endpoint

### DIFF
--- a/src/chains/urls.py
+++ b/src/chains/urls.py
@@ -6,5 +6,5 @@ app_name = "chains"
 
 urlpatterns = [
     path("", ChainsListView.as_view(), name="list"),
-    path("<pk>", ChainsDetailView.as_view(), name="detail"),
+    path("<pk>/", ChainsDetailView.as_view(), name="detail"),
 ]


### PR DESCRIPTION
- `/api/v1/chains/<id>/` should now return the correct response – `200` if the `id` exists, instead of a `404`
- `/api/v1/chains/<id>` (no trailing slash) now redirects (`HTTP 301`) to the endpoint with the trailing slash. The configuration that enables this behaviour is `APPEND_SLASH` which is enabled by default