### PR TITLE
Remove route slicing from logger

### DIFF
--- a/src/config/middleware.py
+++ b/src/config/middleware.py
@@ -22,9 +22,7 @@ class LoggingMiddleware:
         # after view is called
         if request.resolver_match:
             route = (
-                request.resolver_match.route[1:]
-                if request.resolver_match
-                else request.path
+                request.resolver_match.route if request.resolver_match else request.path
             )
             self.logger.info(
                 "MT::%s::%s::%s::%d::%s",


### PR DESCRIPTION
Remove Logging Middleware route slicing – it was removing first character of the route which is not the intended behaviour 