### PR TITLE
Set gasPriceOracle to null if its url is null

### DIFF
--- a/src/chains/serializers.py
+++ b/src/chains/serializers.py
@@ -56,4 +56,6 @@ class ChainSerializer(serializers.ModelSerializer):
     @staticmethod
     @swagger_serializer_method(serializer_or_field=GasPriceOracleSerializer)
     def get_gas_price_oracle(obj):
+        if obj.gas_price_oracle_url is None:
+            return None
         return GasPriceOracleSerializer(obj).data

--- a/src/chains/tests/test_views.py
+++ b/src/chains/tests/test_views.py
@@ -173,3 +173,29 @@ class ChainDetailViewTests(APITestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, json_response)
+
+    def test_null_oracle_url_should_return_null_object(self):
+        chain = ChainFactory.create(id=1, gas_price_oracle_url=None)
+        url = reverse("v1:chains:detail", args=[1])
+        json_response = {
+            "chain_id": str(chain.id),
+            "chain_name": chain.name,
+            "rpc_url": chain.rpc_url,
+            "block_explorer_url": chain.block_explorer_url,
+            "native_currency": {
+                "name": chain.currency_name,
+                "symbol": chain.currency_symbol,
+                "decimals": chain.currency_decimals,
+            },
+            "transaction_service": chain.transaction_service_url,
+            "theme": {
+                "text_color": chain.theme_text_color,
+                "background_color": chain.theme_background_color,
+            },
+            "gas_price_oracle": None,
+        }
+
+        response = self.client.get(path=url, data=None, format="json")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, json_response)


### PR DESCRIPTION
- In the Json response of `/chains`, the `gasPriceOracle` is now `null` if its url (`gasPriceOracle.url`) is also `null`
- This was done in order to simplify the validation of some fields on the client side

Before:

```javascript
{
  ...
  "gasPriceOracle": {
    "url": null,
    "parameter": null
  }
}
```

After:

```javascript
{
  ...
  "gasPriceOracle": null
}
```