### PR TITLE
Remove image minor version declaration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.6-alpine3.13 as production
+FROM python:3.9-alpine as production
 
 # python
 ENV PYTHONUNBUFFERED=1 \


### PR DESCRIPTION
- Remove Docker image minor version declaration
- Image should be resolved to the latest `alpine` release of `Python 3.9`