### PR TITLE
Use factory.Sequence for unique values

### DIFF
--- a/src/chains/tests/factories.py
+++ b/src/chains/tests/factories.py
@@ -8,7 +8,7 @@ class ChainFactory(DjangoModelFactory):
     class Meta:
         model = Chain
 
-    id = factory.Faker("pyint")
+    id = factory.Sequence(lambda id: id)
     relevance = factory.Faker("pyint")
     name = factory.Faker("company")
     rpc_url = factory.Faker("url")

--- a/src/safe_apps/tests/factories.py
+++ b/src/safe_apps/tests/factories.py
@@ -16,7 +16,7 @@ class SafeAppFactory(DjangoModelFactory):
     class Meta:
         model = SafeApp
 
-    app_id = factory.Faker("pyint")
+    app_id = factory.Sequence(lambda id: id)
     visible = True
     url = factory.Faker("url")
     name = factory.Faker("company")


### PR DESCRIPTION
- Use `factory.Sequence` to generate unique values for the primary keys of `Chain` and `SafeApp`
- Previously there was a chance that some tests could fail randomly due to the duplicate ids generated by the Factories