### PR TITLE
Add missing coincurve build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,11 @@ ENV PATH="${PATH}:${PYTHONUSERBASE}/bin"
 
 RUN set -ex \
     && apk add --no-cache --virtual .build-deps \
+    autoconf \
+    automake \
     build-base \
     libffi-dev \
+    libtool \
     postgresql-dev \
     tini
 


### PR DESCRIPTION
- Add `autoconf`, `automake` and `libtool` which are required to build `coincurve`