### PR TITLE
Force web3.py version to 5.18

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,3 @@ flake8==3.9.2
 isort==5.9.2
 pre-commit==2.13.0
 pytest-django==4.4.0
-web3==5.20.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ drf-yasg[validation]==1.20.0
 gnosis-py==3.1.11
 gunicorn==20.1.0
 psycopg2-binary==2.9.1
+web3==5.18 # This should be removed once gnosis-py is updated with the newer version of web3.py


### PR DESCRIPTION
- The latest web3 interface is not compatible with `ethereum_client.py` from `gnosis-py` (`transaction_formatter` is no longer available under `web3._utils.method_formatters`)