### PR TITLE
Fix validation error field reference

### DIFF
--- a/src/chains/models.py
+++ b/src/chains/models.py
@@ -66,7 +66,7 @@ class Chain(models.Model):
             raise ValidationError(
                 {
                     "gas_price_oracle_url": "An oracle url or fixed gas price should be provided (but not both)",
-                    "gas_price_fixed": "An oracle url or fixed gas price should be provided (but not both)",
+                    "gas_price_fixed_wei": "An oracle url or fixed gas price should be provided (but not both)",
                 }
             )
         if self.gas_price_oracle_parameter and self.gas_price_oracle_url is None:


### PR DESCRIPTION
- Fixes an issue when saving an invalid form where when the Gas Price (fixed) and Gas Price oracle were not set (or were both set) would crash the application
- The reason is that the validation error map was referencing the wrong field `gas_price_fixed` instead of `gas_price_fixed_wei`


```
ValueError: 'ChainForm' has no field named 'gas_price_fixed'
```