### PR TITLE
Oracle parameter is required if oracle is set

### DIFF
--- a/src/chains/models.py
+++ b/src/chains/models.py
@@ -69,11 +69,12 @@ class Chain(models.Model):
                     "gas_price_fixed_wei": "An oracle url or fixed gas price should be provided (but not both)",
                 }
             )
-        if self.gas_price_oracle_parameter and self.gas_price_oracle_url is None:
+        if (
+            self.gas_price_oracle_url is not None
+            and self.gas_price_oracle_parameter is None
+        ):
             raise ValidationError(
-                {
-                    "gas_price_oracle_parameter": "An oracle parameter was set with no Oracle url"
-                }
+                {"gas_price_oracle_parameter": "The oracle parameter should be set"}
             )
 
     def __str__(self):

--- a/src/chains/models.py
+++ b/src/chains/models.py
@@ -66,7 +66,7 @@ class Chain(models.Model):
             raise ValidationError(
                 {
                     "gas_price_oracle_url": "An oracle url or fixed gas price should be provided (but not both)",
-                    "gas_price_fixed": "An oracle url or fixed gas price should be provided (but not both)",
+                    "gas_price_fixed_wei": "An oracle url or fixed gas price should be provided (but not both)",
                 }
             )
         if self.gas_price_oracle_parameter and self.gas_price_oracle_url is None:

--- a/src/chains/tests/test_models.py
+++ b/src/chains/tests/test_models.py
@@ -48,7 +48,9 @@ class ChainGasPriceOracleTestCase(TestCase):
 
     def test_oracle_gas_parameter_with_null_url(self):
         chain = ChainFactory.create(
-            gas_price_oracle_url=None, gas_price_oracle_parameter="fake parameter"
+            gas_price_oracle_url=None,
+            gas_price_oracle_parameter="fake parameter",
+            gas_price_fixed_wei=None,
         )
 
         with self.assertRaises(ValidationError):
@@ -61,8 +63,8 @@ class ChainGasPriceOracleTestCase(TestCase):
             gas_price_fixed_wei=None,
         )
 
-        # No validation exception should be thrown
-        chain.full_clean()
+        with self.assertRaises(ValidationError):
+            chain.full_clean()
 
     def test_oracle_gas_parameter_with_url(self):
         chain = ChainFactory.create(


### PR DESCRIPTION
- When the oracle url is set then the oracle parameter should also be required

```javascript
{
  "type": "oracle",
  "url": <string>, // required
  "gasParameter": <string>, // required
  "gweiFactor": <stringified-number>, // optional
}
```