### PR TITLE
Chore: Fix script to run commands inside docker container, extend .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ coverage.xml
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
+staticfiles/
 
 # Flask stuff:
 instance/
@@ -132,3 +133,4 @@ dmypy.json
 .idea/
 data/
 docker-compose.override.yml
+.vscode/

--- a/run
+++ b/run
@@ -31,10 +31,10 @@ function manage {
 
   # We need to collectstatic before we run our tests.
   if [ "${1-''}" == "test" ]; then
-    cmd python manage.py collectstatic --no-input
+    cmd python src/manage.py collectstatic --no-input
   fi
 
-  cmd python manage.py "${@}"
+  cmd python src/manage.py "${@}"
 }
 
 function help {


### PR DESCRIPTION
What this PR does:
- add vscode settings dir and `staticfiles` to `.gitignore` improvements for vscode
- (?) fix manage.py directory in the `run` script