### PR TITLE
Bump gnosis-py from 3.1.13 to 3.1.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ django-cors-headers==3.7.0
 djangorestframework==3.12.4
 djangorestframework-camel-case==1.2.0
 drf-yasg[validation]==1.20.0
-gnosis-py==3.1.13
+gnosis-py==3.1.14
 gunicorn==20.1.0
 psycopg2-binary==2.9.1
-web3==5.18 # This should be removed once gnosis-py is updated with the newer version of web3.py


### PR DESCRIPTION
- Bump `gnosis-py` from 3.1.13 to 3.1.14
- `web3` is no longer required to be set since the new version of `gnosis-py` correctly sets the version range