### PR TITLE
Fix migration reverse lambda args

### DIFF
--- a/src/chains/migrations/0019_add_safe_apps_rpc.py
+++ b/src/chains/migrations/0019_add_safe_apps_rpc.py
@@ -14,7 +14,6 @@ def copy_rpc_fields(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("chains", "0018_chain_rpc_authentication"),
     ]
@@ -40,5 +39,5 @@ class Migration(migrations.Migration):
                 default="",
             ),
         ),
-        migrations.RunPython(copy_rpc_fields, lambda **args: None),
+        migrations.RunPython(copy_rpc_fields, lambda apps, schema_editor: None),
     ]


### PR DESCRIPTION
- Fix `TypeError: <lambda>() takes 0 positional arguments but 2 were given`
- The reverse function should take two positional arguments and should be declared in the lambda
- This issue prevents migration `0019` to be able to reverse