### PR TITLE
Add CGW Chains webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,12 @@ POSTGRES_PORT=5432
 # This setting is intended for development. It will cause workers to be restarted whenever application code changes.
 GUNICORN_WEB_RELOAD=false
 
+# The Client Gateway URL. This is for triggering webhooks to invalidate its cache for example
+#CGW_URL=http://127.0.0.1
+
+# The Client Gateway /flush token.
+#CGW_FLUSH_TOKEN=example-flush-token
+
 # What CPU and memory constraints will be added to your services? When left at
 # 0, they will happily use as much as needed.
 #DOCKER_POSTGRES_CPUS=0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ flake8==3.9.2
 isort==5.9.2
 pre-commit==2.13.0
 pytest-django==4.4.0
+responses==0.13.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ drf-yasg[validation]==1.20.0
 gnosis-py==3.1.14
 gunicorn==20.1.0
 psycopg2-binary==2.9.1
+requests==2.26.0

--- a/src/chains/apps.py
+++ b/src/chains/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class AppsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "chains"
+
+    def ready(self):
+        import chains.signals  # noqa: F401

--- a/src/chains/signals.py
+++ b/src/chains/signals.py
@@ -1,0 +1,44 @@
+import logging
+from functools import cache
+from urllib.parse import urljoin
+
+import requests
+from django.conf import settings
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
+
+from .models import Chain
+
+logger = logging.getLogger(__name__)
+
+
+@cache
+def setup_session():
+    session = requests.Session()
+    adapter = requests.adapters.HTTPAdapter(max_retries=3)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session
+
+
+@receiver(post_save, sender=Chain)
+@receiver(post_delete, sender=Chain)
+def on_chain_update(sender, **kwargs):
+    logger.info("Chain update. Triggering CGW webhook")
+    cgw_url = settings.CGW_URL
+    if cgw_url is None:
+        logger.error("CGW_URL is not set. Skipping hook call")
+        return
+    cgw_flush_token = settings.CGW_FLUSH_TOKEN
+    if cgw_flush_token is None:
+        logger.error("CGW_FLUSH_TOKEN is not set. Skipping hook call")
+        return
+
+    url = urljoin(cgw_url, f"/v1/flush/{cgw_flush_token}")
+    try:
+        post = setup_session().post(
+            url, json={"invalidate": "Chains"}
+        )  # TODO: if this throws it might leak the token to the logger
+        post.raise_for_status()
+    except Exception as error:
+        logger.error(error)

--- a/src/chains/signals.py
+++ b/src/chains/signals.py
@@ -36,9 +36,7 @@ def on_chain_update(sender, **kwargs):
 
     url = urljoin(cgw_url, f"/v1/flush/{cgw_flush_token}")
     try:
-        post = setup_session().post(
-            url, json={"invalidate": "Chains"}
-        )  # TODO: if this throws it might leak the token to the logger
+        post = setup_session().post(url, json={"invalidate": "Chains"})
         post.raise_for_status()
     except Exception as error:
         logger.error(error)

--- a/src/chains/tests/test_signals.py
+++ b/src/chains/tests/test_signals.py
@@ -1,26 +1,7 @@
-from unittest.mock import patch
-
 import responses
 from django.test import TestCase, override_settings
 
 from chains.tests.factories import ChainFactory
-
-
-class ChainHookTestCase(TestCase):
-    @patch("requests.sessions.Session.post")
-    def test_on_chain_update_with_no_cgw_set(self, mock_post):
-        ChainFactory.create()
-
-        assert not mock_post.called
-
-    @patch("requests.sessions.Session.post")
-    @override_settings(
-        CGW_URL="http://127.0.0.1",
-    )
-    def test_on_chain_update_with_no_flush_token_set(self, mock_post):
-        ChainFactory.create()
-
-        assert not mock_post.called
 
 
 @override_settings(
@@ -90,3 +71,23 @@ class ChainNetworkHookTestCase(TestCase):
 
         # 2 calls: one for creation and one for updating
         assert len(responses.calls) == 2
+
+    @override_settings(
+        CGW_URL=None,
+        CGW_FLUSH_TOKEN=None,
+    )
+    @responses.activate
+    def test_on_chain_update_with_no_cgw_set(self):
+        ChainFactory.create()
+
+        assert len(responses.calls) == 0
+
+    @override_settings(
+        CGW_URL="http://127.0.0.1",
+        CGW_FLUSH_TOKEN=None,
+    )
+    @responses.activate
+    def test_on_chain_update_with_no_flush_token_set(self):
+        ChainFactory.create()
+
+        assert len(responses.calls) == 0

--- a/src/chains/tests/test_signals.py
+++ b/src/chains/tests/test_signals.py
@@ -1,0 +1,92 @@
+from unittest.mock import patch
+
+import responses
+from django.test import TestCase, override_settings
+
+from chains.tests.factories import ChainFactory
+
+
+class ChainHookTestCase(TestCase):
+    @patch("requests.sessions.Session.post")
+    def test_on_chain_update_with_no_cgw_set(self, mock_post):
+        ChainFactory.create()
+
+        assert not mock_post.called
+
+    @patch("requests.sessions.Session.post")
+    @override_settings(
+        CGW_URL="http://127.0.0.1",
+    )
+    def test_on_chain_update_with_no_flush_token_set(self, mock_post):
+        ChainFactory.create()
+
+        assert not mock_post.called
+
+
+@override_settings(
+    CGW_URL="http://127.0.0.1",
+    CGW_FLUSH_TOKEN="example-token",
+)
+class ChainNetworkHookTestCase(TestCase):
+    @responses.activate
+    def test_on_chain_update_hook_200(self):
+        responses.add(
+            responses.POST,
+            "http://127.0.0.1/v1/flush/example-token",
+            status=200,
+            match=[responses.json_params_matcher({"invalidate": "Chains"})],
+        )
+
+        ChainFactory.create()
+
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
+        assert (
+            responses.calls[0].request.url == "http://127.0.0.1/v1/flush/example-token"
+        )
+
+    @responses.activate
+    def test_on_chain_update_hook_400(self):
+        responses.add(
+            responses.POST,
+            "http://127.0.0.1/v1/flush/example-token",
+            status=400,
+            match=[responses.json_params_matcher({"invalidate": "Chains"})],
+        )
+
+        ChainFactory.create()
+
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_on_chain_update_hook_500(self):
+        responses.add(
+            responses.POST,
+            "http://127.0.0.1/v1/flush/example-token",
+            status=500,
+            match=[responses.json_params_matcher({"invalidate": "Chains"})],
+        )
+
+        ChainFactory.create()
+
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_on_chain_delete_hook_call(self):
+        chain = ChainFactory.create()
+
+        chain.delete()
+
+        # 2 calls: one for creation and one for deletion
+        assert len(responses.calls) == 2
+
+    @responses.activate
+    def test_on_chain_update_hook_call(self):
+        chain = ChainFactory.create()
+
+        # Not updating using queryset because hooks are not triggered that way
+        chain.currency_name = "Ether"
+        chain.save()
+
+        # 2 calls: one for creation and one for updating
+        assert len(responses.calls) == 2

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -190,3 +190,6 @@ SWAGGER_SETTINGS = {
 
 CORS_ALLOW_ALL_ORIGINS = True
 CORS_URLS_REGEX = r"^/api/.*$"
+
+CGW_URL = os.environ.get("CGW_URL")
+CGW_FLUSH_TOKEN = os.environ.get("CGW_FLUSH_TOKEN")


### PR DESCRIPTION
Closes #173 

- Client Gateway hook implementation – this hook is triggered when a `Chain` is updated, created or deleted
- Add two new environment variables: one for the client gateway url (`CGW_URL`) and another one for the flush token (`CGW_FLUSH_TOKEN`)