### PR TITLE
Check pending Django migrations in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,8 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements-dev.txt
+      - name: Check pending migrations
+        run: python src/manage.py makemigrations --check --dry-run
       - name: Run migrations
         run: python src/manage.py migrate
       - name: Django System Check


### PR DESCRIPTION
- Add step to CI to check if there are any migrations that should've been created and were not created (without creating them)