### PR TITLE
Use POSTGRES_PORT only for host port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     volumes:
       - ./data/db:/var/lib/postgresql/data
     ports:
-      - "${POSTGRES_PORT}:${POSTGRES_PORT}"
+      - "${POSTGRES_PORT}:5432"
   web:
     build: .
     tty: true


### PR DESCRIPTION
- `POSTGRES_PORT` should be used only for the host port mapping
- Using `POSTGRES_PORT` for the container port would map it to a port where the `db` is not running