### PR TITLE
Add Pillow build dependencies to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,18 @@ RUN set -ex \
     libffi-dev \
     libtool \
     postgresql-dev \
-    tini
+    tini \
+    # Pillow dependencies
+    freetype-dev \
+    fribidi-dev \
+    harfbuzz-dev \
+    jpeg-dev \
+    lcms2-dev \
+    openjpeg-dev \
+    tcl-dev \
+    tiff-dev \
+    tk-dev \
+    zlib-dev
 
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
Since the introduction of `Pillow` in da146ef, additional build dependencies are required which were not present in the `Dockerfile` – https://pillow.readthedocs.io/en/latest/installation.html#building-on-linux