### PR TITLE
Use python:3.9-slim as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,45 +1,27 @@
-FROM python:3.9-alpine as production
+FROM python:3.9-slim as production
 
 # python
-ENV PYTHONUNBUFFERED=1 \
-    # prevents python creating .pyc files
-    PYTHONDONTWRITEBYTECODE=1 \
-    \
-    # pip
-    PIP_NO_CACHE_DIR=off \
-    PIP_DISABLE_PIP_VERSION_CHECK=on \
-    PIP_DEFAULT_TIMEOUT=100 \
-    CRYPTOGRAPHY_DONT_BUILD_RUST=1
+ENV PYTHONUNBUFFERED=1
 
 ENV PYTHONUSERBASE=/python-deps
 ENV PATH="${PATH}:${PYTHONUSERBASE}/bin"
 
-RUN set -ex \
-    && apk add --no-cache --virtual .build-deps \
-    autoconf \
-    automake \
-    build-base \
-    libffi-dev \
-    libtool \
-    postgresql-dev \
-    tini \
-    # Pillow dependencies
-    freetype-dev \
-    fribidi-dev \
-    harfbuzz-dev \
-    jpeg-dev \
-    lcms2-dev \
-    openjpeg-dev \
-    tcl-dev \
-    tiff-dev \
-    tk-dev \
-    zlib-dev
-
 WORKDIR /app
 COPY . .
-RUN pip3 install --no-warn-script-location --user -r requirements.txt
 
-ENTRYPOINT ["/sbin/tini", "--", "./docker-entrypoint.sh"]
+RUN set ex \
+    && buildDeps=" \
+		gcc \
+		libc-dev \
+		" \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends $buildDeps tini \
+    && pip3 install --no-cache-dir --user -r requirements.txt \
+    && apt-get purge -y --auto-remove $buildDeps \
+    && rm -rf /var/lib/apt/lists/* \
+    && chmod +x /usr/bin/tini
+
+ENTRYPOINT ["/usr/bin/tini", "--", "./docker-entrypoint.sh"]
 
 # ------- development image -------
 FROM production as development

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 
 set -euo pipefail
 


### PR DESCRIPTION
- Use `python-slim` instead of `python-alpine` as a base image
- Even though alpine is usually smaller, due to the lack of installed dependencies we would have to manage manually which dependencies were required for building the project and which ones were required for runtime
- This can be quite cumbersome due to the number of dependencies required by imaging libraries like `Pillow` which many of those were not present in the `alpine` image

**Non compressed sizes:**
|   |  Before (alpine) | After (slim)  |  % decreased |
|---|---|---|---|
|  production |  842MB  |  333MB | ~ 60%  |
| dev              |  867MB  |  371MB  |   ~ 57% |