### PR TITLE
Migrate to responses.matchers.json_params_matcher

### DIFF
--- a/src/chains/tests/test_signals.py
+++ b/src/chains/tests/test_signals.py
@@ -15,7 +15,7 @@ class ChainNetworkHookTestCase(TestCase):
             responses.POST,
             "http://127.0.0.1/v1/flush/example-token",
             status=200,
-            match=[responses.json_params_matcher({"invalidate": "Chains"})],
+            match=[responses.matchers.json_params_matcher({"invalidate": "Chains"})],
         )
 
         ChainFactory.create()
@@ -32,7 +32,7 @@ class ChainNetworkHookTestCase(TestCase):
             responses.POST,
             "http://127.0.0.1/v1/flush/example-token",
             status=400,
-            match=[responses.json_params_matcher({"invalidate": "Chains"})],
+            match=[responses.matchers.json_params_matcher({"invalidate": "Chains"})],
         )
 
         ChainFactory.create()
@@ -45,7 +45,7 @@ class ChainNetworkHookTestCase(TestCase):
             responses.POST,
             "http://127.0.0.1/v1/flush/example-token",
             status=500,
-            match=[responses.json_params_matcher({"invalidate": "Chains"})],
+            match=[responses.matchers.json_params_matcher({"invalidate": "Chains"})],
         )
 
         ChainFactory.create()


### PR DESCRIPTION
The new release of `responses` (https://github.com/getsentry/responses/releases/tag/0.14.0) moved `responses.json_params_matcher` to `responses.matchers.json_param_matcher` so `responses.json_params_matcher` is now deprecated.