### PR TITLE
Fix currency_logo_uri field length issue

### DIFF
--- a/src/chains/migrations/0025_alter_chain_currency_logo_uri.py
+++ b/src/chains/migrations/0025_alter_chain_currency_logo_uri.py
@@ -15,6 +15,8 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="chain",
             name="currency_logo_uri",
-            field=models.ImageField(upload_to=chains.models.native_currency_path),
+            field=models.ImageField(
+                max_length=255, upload_to=chains.models.native_currency_path
+            ),
         ),
     ]

--- a/src/chains/models.py
+++ b/src/chains/models.py
@@ -50,7 +50,9 @@ class Chain(models.Model):
     currency_name = models.CharField(max_length=255)
     currency_symbol = models.CharField(max_length=255)
     currency_decimals = models.IntegerField(default=18)
-    currency_logo_uri = models.ImageField(upload_to=native_currency_path)
+    currency_logo_uri = models.ImageField(
+        upload_to=native_currency_path, max_length=255
+    )
     transaction_service_uri = models.URLField()
     theme_text_color = models.CharField(
         validators=[color_validator],


### PR DESCRIPTION
- Set `max_length` of `currency_logo_uri` to `255` (max allowed by db)
- When the migration was applied with the production data, it raised the following exception `psycopg2.errors.StringDataRightTruncation: value too long for type character varying(100)`
- This issue is related with the default `max_length` of the `ImageField` (which is `100`) and a production value had an `ImageField` with more than `100` characters