### PR TITLE
Downgrade postgres 13 -> 10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres
+        image: postgres:10-alpine
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     depends_on:
       - web
   db:
-    image: postgres:13-alpine
+    image: postgres:10-alpine
     env_file:
       - .env
     volumes:


### PR DESCRIPTION
- We should use it for testing and running the service as it's the
  version currently used on production