### PR TITLE
Add force script name for nested paths on nginx

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -109,6 +109,7 @@ LOGGING = {
 }
 
 ROOT_URLCONF = "config.urls"
+FORCE_SCRIPT_NAME = os.getenv("FORCE_SCRIPT_NAME", default=None)
 
 TEMPLATES = [
     {
@@ -176,8 +177,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.2/howto/static-files/
 
-STATIC_URL = "/static/"
-
+STATIC_URL = "static/"
 STATIC_ROOT = "staticfiles"
 
 # Default primary key field type


### PR DESCRIPTION
- Application was not compatible with nginx paths. Now FORCE_SCRIPT_NAME can be set
as an environment variable to add a base path for all the project
- Closes #242