### PR TITLE
Add Wallet and Feature inlines to ChainAdmin

### DIFF
--- a/src/chains/admin.py
+++ b/src/chains/admin.py
@@ -1,6 +1,19 @@
 from django.contrib import admin
+from django.db.models import Model
 
 from .models import Chain, Feature, GasPrice, Wallet
+
+
+class FeatureInline(admin.TabularInline[Model]):
+    model = Feature.chains.through
+    extra = 0
+    verbose_name_plural = "Features enabled for this chain"
+
+
+class WalletInline(admin.TabularInline[Model]):
+    model = Wallet.chains.through
+    extra = 0
+    verbose_name_plural = "Wallets enabled for this chain"
 
 
 @admin.register(Chain)
@@ -17,6 +30,7 @@ class ChainAdmin(admin.ModelAdmin[Chain]):
         "relevance",
         "name",
     )
+    inlines = [FeatureInline, WalletInline]
 
 
 @admin.register(GasPrice)


### PR DESCRIPTION
- Add `FeatureInline` and `WalletInline` to expose the `through` model of `Feature` and `Wallet` respectively on `ChainAdmin`
- This allows to easily add, change and remove the relationships between `Wallet` and `Chain` and `Feature` and `Chain`

This is an example of the admin view of a specific chain:

![image](https://user-images.githubusercontent.com/3332770/140922875-99266940-7e2f-499d-b996-af5c564c3a58.png)
