### PR TITLE
Use Postgres 13 in docker compose

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:10-alpine
+        image: postgres:13-alpine
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     depends_on:
       - web
   db:
-    image: postgres:10-alpine
+    image: postgres:13-alpine
     env_file:
       - .env
     volumes:


### PR DESCRIPTION
- We are using Postgres 13 in production so we should use the same version when testing locally with `docker compose`