### PR TITLE
Add flake8 commit hook

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,2 @@
 [flake8]
 max-line-length = 119
-extend-ignore = E203, W503
-exclude = src/safe_apps/migrations

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,7 @@ repos:
     hooks:
       - id: black
         language_version: python3
+  - repo: https://github.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8


### PR DESCRIPTION
- Adds `flake8` as a pre-commit hook. `flake8` was already being checked by the CI but this should provide more convenience when we want to run all the commit checks in one go locally
- Remove `extend-ignore` and `exclude` rules from `flake8`. Current source is already compliant without excluding these rules.