### PR TITLE
Omit tests in coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,9 @@
 [run]
+source = src
+
+[report]
 omit =
-    src/chains/tests/factories.py
+    */tests/*
     src/config/asgi.py
     src/config/gunicorn.py
     src/config/swagger_info.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Django System Check
         run: python src/manage.py check
       - name: Run tests with coverage
-        run: coverage run --source=src/ -m pytest src
+        run: coverage run -m pytest src
       - name: Upload coverage
         continue-on-error: true
         env:


### PR DESCRIPTION
- Omit every test folder from the coverage report
- Set `src` as the default to measure coverage