### PR TITLE
Add mypy.ini to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,3 +17,4 @@ docker-compose.yml
 pyproject.toml
 nginx/
 *.md
+mypy.ini


### PR DESCRIPTION
- `mypy.ini` was present in the Docker image even though it's only required when running `mypy` (locally or CI)