### PR TITLE
Set default chains pagination limit to 20

### DIFF
--- a/src/about/tests/test_views.py
+++ b/src/about/tests/test_views.py
@@ -7,7 +7,7 @@ class AboutJsonPayloadFormatViewTests(APITestCase):
         url = reverse("v1:about:detail")
         expected_json_response = {
             "name": "Safe Config Service",
-            "version": "2.8.0",
+            "version": "2.8.1",
             "apiVersion": "v1",
             "secure": False,
         }
@@ -23,7 +23,7 @@ class AboutSecureRequestViewTests(APITestCase):
         url = reverse("v1:about:detail")
         expected_json_response = {
             "name": "Safe Config Service",
-            "version": "2.8.0",
+            "version": "2.8.1",
             "api_version": "v1",
             "secure": True,
         }
@@ -37,7 +37,7 @@ class AboutSecureRequestViewTests(APITestCase):
         url = reverse("v1:about:detail")
         expected_json_response = {
             "name": "Safe Config Service",
-            "version": "2.8.0",
+            "version": "2.8.1",
             "api_version": "v1",
             "secure": False,
         }

--- a/src/chains/tests/test_views.py
+++ b/src/chains/tests/test_views.py
@@ -91,21 +91,21 @@ class ChainJsonPayloadFormatViewTests(APITestCase):
 
 class ChainPaginationViewTests(APITestCase):
     def test_pagination_next_page(self) -> None:
-        ChainFactory.create_batch(11)
+        ChainFactory.create_batch(21)
         url = reverse("v1:chains:list")
 
         response = self.client.get(path=url, data=None, format="json")
 
         self.assertEqual(response.status_code, 200)
         # number of items should be equal to the number of total items
-        self.assertEqual(response.json()["count"], 11)
+        self.assertEqual(response.json()["count"], 21)
         self.assertEqual(
             response.json()["next"],
-            "http://testserver/api/v1/chains/?limit=10&offset=10",
+            "http://testserver/api/v1/chains/?limit=20&offset=20",
         )
         self.assertEqual(response.json()["previous"], None)
         # returned items should be equal to max_limit
-        self.assertEqual(len(response.json()["results"]), 10)
+        self.assertEqual(len(response.json()["results"]), 20)
 
     def test_request_more_than_max_limit_should_return_max_limit(self) -> None:
         ChainFactory.create_batch(101)
@@ -126,18 +126,18 @@ class ChainPaginationViewTests(APITestCase):
         self.assertEqual(len(response.json()["results"]), 100)
 
     def test_offset_greater_than_count(self) -> None:
-        ChainFactory.create_batch(11)
+        ChainFactory.create_batch(21)
         # requesting offset of number of chains
-        url = reverse("v1:chains:list") + f'{"?offset=11"}'
+        url = reverse("v1:chains:list") + f'{"?offset=21"}'
 
         response = self.client.get(path=url, data=None, format="json")
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["count"], 11)
+        self.assertEqual(response.json()["count"], 21)
         self.assertEqual(response.json()["next"], None)
         self.assertEqual(
             response.json()["previous"],
-            "http://testserver/api/v1/chains/?limit=10&offset=1",
+            "http://testserver/api/v1/chains/?limit=20&offset=1",
         )
         # returned items should still be zero
         self.assertEqual(len(response.json()["results"]), 0)

--- a/src/chains/views.py
+++ b/src/chains/views.py
@@ -15,7 +15,7 @@ class ChainsListView(ListAPIView):
     serializer_class = ChainSerializer
     pagination_class = LimitOffsetPagination
     pagination_class.max_limit = 100
-    pagination_class.default_limit = 10
+    pagination_class.default_limit = 20
     queryset = Chain.objects.all()
     filter_backends = [filters.OrderingFilter]
     ordering_fields = ["relevance", "name"]

--- a/src/version.py
+++ b/src/version.py
@@ -1,2 +1,2 @@
 __name__ = "Safe Config Service"
-__version__ = "2.8.0"
+__version__ = "2.8.1"


### PR DESCRIPTION
- Increase the default pagination limit from `10` to `20`
- This mitigates an issue where `safe-react` would only request the default number of chains even if more than `10` are available