### PR TITLE
Bump Django from 3.2.10 to 4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3==1.20.26
-Django==3.2.10
+Django==4.0
 django-cors-headers==3.10.1
 djangorestframework==3.13.1
 djangorestframework-camel-case==1.3.0

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -185,8 +185,6 @@ TIME_ZONE = "UTC"
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)


### PR DESCRIPTION
- Bump Django to version 4 – Release Notes: https://docs.djangoproject.com/en/4.0/releases/4.0/
- Remove `USE_L10N` from `settings.py` – the default value is now `True`
  * Additionally, this setting is deprecated: _"Starting with Django 5.0, localized formatting of data will always be enabled. For example Django will display numbers and dates using the format of the current locale"_ – https://docs.djangoproject.com/en/4.0/ref/settings/#use-l10n