### PR TITLE
Add GET /safe-apps client_url param to swagger, align chainId param/variable naming

### DIFF
--- a/src/safe_apps/tests/test_views.py
+++ b/src/safe_apps/tests/test_views.py
@@ -210,7 +210,7 @@ class FilterSafeAppListViewTests(APITestCase):
 
     def test_apps_returned_on_non_existent_client_url(self) -> None:
         safe_app = SafeAppFactory.create()
-        url = reverse("v1:safe-apps:list") + f'{"?client_url=non_existent_host"}'
+        url = reverse("v1:safe-apps:list") + f'{"?clientUrl=non_existent_host"}'
 
         response = self.client.get(path=url, data=None, format="json")
 
@@ -233,7 +233,7 @@ class FilterSafeAppListViewTests(APITestCase):
 
     def test_apps_returned_on_empty_client_url(self) -> None:
         safe_app = SafeAppFactory.create()
-        url = reverse("v1:safe-apps:list") + f'{"?client_url="}'
+        url = reverse("v1:safe-apps:list") + f'{"?clientUrl="}'
 
         response = self.client.get(path=url, data=None, format="json")
 
@@ -275,8 +275,7 @@ class FilterSafeAppListViewTests(APITestCase):
             }
         ]
         url = (
-            reverse("v1:safe-apps:list")
-            + f'{"?client_url=pump.com&client_url=safe.com"}'
+            reverse("v1:safe-apps:list") + f'{"?clientUrl=pump.com&clientUrl=safe.com"}'
         )
 
         response = self.client.get(path=url, data=None, format="json")
@@ -339,7 +338,7 @@ class FilterSafeAppListViewTests(APITestCase):
                 },
             },
         ]
-        url = reverse("v1:safe-apps:list") + f'{"?client_url=safe.com"}'
+        url = reverse("v1:safe-apps:list") + f'{"?clientUrl=safe.com"}'
 
         response = self.client.get(path=url, data=None, format="json")
 

--- a/src/safe_apps/views.py
+++ b/src/safe_apps/views.py
@@ -24,9 +24,9 @@ class SafeAppsListView(ListAPIView):
         type=openapi.TYPE_INTEGER,
     )
     _swagger_client_url_param = openapi.Parameter(
-        "client_url",
+        "clientUrl",
         openapi.IN_QUERY,
-        description="Used to filter Safe Apps that are available on `client_url`",
+        description="Used to filter Safe Apps that are available on `clientUrl`",
         type=openapi.TYPE_STRING,
     )
 
@@ -46,7 +46,7 @@ class SafeAppsListView(ListAPIView):
         if network_id is not None and network_id.isdigit():
             queryset = queryset.filter(chain_ids__contains=[network_id])
 
-        host = self.request.query_params.get("client_url")
+        host = self.request.query_params.get("clientUrl")
         if host is not None:
             queryset = queryset.filter(
                 Q(exclusive_clients__url=host) | Q(exclusive_clients__isnull=True)

--- a/src/safe_apps/views.py
+++ b/src/safe_apps/views.py
@@ -17,13 +17,13 @@ class SafeAppsListView(ListAPIView):
     serializer_class = SafeAppsResponseSerializer
     pagination_class = None
 
-    _swagger_network_id_param = openapi.Parameter(
+    _swagger_chain_id_param = openapi.Parameter(
         "chainId",
         openapi.IN_QUERY,
         description="Used to filter Safe Apps that are available on `chainId`",
         type=openapi.TYPE_INTEGER,
     )
-    _swagger_host_param = openapi.Parameter(
+    _swagger_client_url_param = openapi.Parameter(
         "client_url",
         openapi.IN_QUERY,
         description="Used to filter Safe Apps that are available on `client_url`",
@@ -31,7 +31,7 @@ class SafeAppsListView(ListAPIView):
     )
 
     @method_decorator(cache_page(60 * 10, cache="safe-apps"))  # Cache 10 minutes
-    @swagger_auto_schema(manual_parameters=[_swagger_network_id_param])  # type: ignore[misc]
+    @swagger_auto_schema(manual_parameters=[_swagger_chain_id_param, _swagger_client_url_param])  # type: ignore[misc]
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         Returns a collection of Safe Apps (across different chains).


### PR DESCRIPTION
This PR fixes:
- In my previous PR for access control for Safe Apps I forgot to include client_url param to swagger parameters
- (nit) Aligns naming between chainId param and the variable naming
- convert `client_url` to camelCase in tests/views