### PR TITLE
Bug: apps are filtered by the client if clientUrl param is empty

### DIFF
--- a/src/chains/models.py
+++ b/src/chains/models.py
@@ -1,6 +1,6 @@
 import os
 import re
-from typing import IO
+from typing import IO, Union
 
 from django.core.exceptions import ValidationError
 from django.core.files.images import get_image_dimensions
@@ -26,7 +26,7 @@ def native_currency_path(instance: "Chain", filename: str) -> str:
     return f"chains/{instance.id}/currency_logo{file_extension}"
 
 
-def validate_native_currency_size(image: str | IO[bytes]) -> None:
+def validate_native_currency_size(image: Union[str, IO[bytes]]) -> None:
     image_width, image_height = get_image_dimensions(image)
     if image_width > 512 or image_height > 512:
         raise ValidationError("Image width and height need to be at most 512 pixels")

--- a/src/safe_apps/tests/test_views.py
+++ b/src/safe_apps/tests/test_views.py
@@ -232,24 +232,39 @@ class FilterSafeAppListViewTests(APITestCase):
         self.assertEqual(response.json(), json_response)
 
     def test_apps_returned_on_empty_client_url(self) -> None:
-        safe_app = SafeAppFactory.create()
+        client_1 = ClientFactory.create(url="safe.com")
+        safe_app_1 = SafeAppFactory.create()
+        safe_app_2 = SafeAppFactory.create(exclusive_clients=(client_1,))
         url = reverse("v1:safe-apps:list") + f'{"?clientUrl="}'
 
         response = self.client.get(path=url, data=None, format="json")
 
         json_response = [
             {
-                "id": safe_app.app_id,
-                "url": safe_app.url,
-                "name": safe_app.name,
-                "iconUrl": safe_app.icon_url,
-                "description": safe_app.description,
-                "chainIds": safe_app.chain_ids,
+                "id": safe_app_1.app_id,
+                "url": safe_app_1.url,
+                "name": safe_app_1.name,
+                "iconUrl": safe_app_1.icon_url,
+                "description": safe_app_1.description,
+                "chainIds": safe_app_1.chain_ids,
                 "provider": None,
                 "accessControl": {
                     "type": "NO_RESTRICTIONS",
                 },
-            }
+            },
+            {
+                "id": safe_app_2.app_id,
+                "url": safe_app_2.url,
+                "name": safe_app_2.name,
+                "iconUrl": safe_app_2.icon_url,
+                "description": safe_app_2.description,
+                "chainIds": safe_app_2.chain_ids,
+                "provider": None,
+                "accessControl": {
+                    "type": "DOMAIN_ALLOWLIST",
+                    "value": [client_1.url],
+                },
+            },
         ]
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), json_response)

--- a/src/safe_apps/views.py
+++ b/src/safe_apps/views.py
@@ -47,7 +47,7 @@ class SafeAppsListView(ListAPIView):
             queryset = queryset.filter(chain_ids__contains=[chain_id])
 
         client_url = self.request.query_params.get("clientUrl")
-        if client_url is not None and client_url:
+        if client_url:
             queryset = queryset.filter(
                 Q(exclusive_clients__url=client_url) | Q(exclusive_clients__isnull=True)
             )

--- a/src/safe_apps/views.py
+++ b/src/safe_apps/views.py
@@ -46,7 +46,7 @@ class SafeAppsListView(ListAPIView):
         if chain_id is not None and chain_id.isdigit():
             queryset = queryset.filter(chain_ids__contains=[chain_id])
 
-        client_url = self.request.query_params.get("clientUrl", None)
+        client_url = self.request.query_params.get("clientUrl")
         if client_url is not None and client_url:
             queryset = queryset.filter(
                 Q(exclusive_clients__url=client_url) | Q(exclusive_clients__isnull=True)

--- a/src/safe_apps/views.py
+++ b/src/safe_apps/views.py
@@ -42,14 +42,14 @@ class SafeAppsListView(ListAPIView):
     def get_queryset(self) -> QuerySet[SafeApp]:
         queryset = SafeApp.objects.filter(visible=True)
 
-        network_id = self.request.query_params.get("chainId")
-        if network_id is not None and network_id.isdigit():
-            queryset = queryset.filter(chain_ids__contains=[network_id])
+        chain_id = self.request.query_params.get("chainId")
+        if chain_id is not None and chain_id.isdigit():
+            queryset = queryset.filter(chain_ids__contains=[chain_id])
 
-        host = self.request.query_params.get("clientUrl")
-        if host is not None:
+        client_url = self.request.query_params.get("clientUrl", None)
+        if client_url is not None and client_url:
             queryset = queryset.filter(
-                Q(exclusive_clients__url=host) | Q(exclusive_clients__isnull=True)
+                Q(exclusive_clients__url=client_url) | Q(exclusive_clients__isnull=True)
             )
 
         return queryset


### PR DESCRIPTION
When writing tests for the safe-client-gateway, I discovered that if you specify an empty `clientUrl` query param, the apps would still get filtered by an empty string. In this PR:
- add a check for an empty `clientUrl` param and extend the test
- rename the variable for `chainId` param from `network_id` to `chain_id` to match the param name and use the same approach for client_url
- Use `Union` for type definitions instead of `|` to remove hard requirements on python 3.10+