### PR TITLE
support for trusted csrf origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,3 +114,8 @@ DEFAULT_FILE_STORAGE=storages.backends.s3boto3.S3Boto3Storage
 # This is just the domain name ie.: no protocol should be set here and it should not end in a slash `/`
 # eg.: AWS_S3_CUSTOM_DOMAIN=cdn.mydomain.com
 #AWS_S3_CUSTOM_DOMAIN=
+
+# CSRF protection 
+# See https://docs.djangoproject.com/en/4.0/ref/settings/#std:setting-CSRF_TRUSTED_ORIGINS
+#CSRF_TRUSTED_ORIGINS="https://safe-config.staging.gnosisdev.com,http://safe-config.staging.gnosisdev.com"
+#CSRF_TRUSTED_ORIGINS="https://safe-config.gnosis.io,http://safe-config.gnosis.io"

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -230,5 +230,8 @@ DEFAULT_FILE_STORAGE = os.getenv(
 
 # SECURITY
 # https://docs.djangoproject.com/en/4.0/ref/settings/#csrf-trusted-origins
-allowed_csrf_origins = os.getenv("CSRF_TRUSTED_ORIGINS", "")
-CSRF_TRUSTED_ORIGINS = [allowed_csrf_origins.strip() for allowed_csrf_origins in allowed_csrf_origins.split(",")]
+allowed_csrf_origins = os.getenv("CSRF_TRUSTED_ORIGINS", "http://127.0.0.1")
+CSRF_TRUSTED_ORIGINS = [
+    allowed_csrf_origins.strip()
+    for allowed_csrf_origins in allowed_csrf_origins.split(",")
+]

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -230,8 +230,9 @@ DEFAULT_FILE_STORAGE = os.getenv(
 
 # SECURITY
 # https://docs.djangoproject.com/en/4.0/ref/settings/#csrf-trusted-origins
-allowed_csrf_origins = os.getenv("CSRF_TRUSTED_ORIGINS", "http://127.0.0.1")
-CSRF_TRUSTED_ORIGINS = [
-    allowed_csrf_origins.strip()
-    for allowed_csrf_origins in allowed_csrf_origins.split(",")
-]
+allowed_csrf_origins = os.getenv("CSRF_TRUSTED_ORIGINS", "")
+if allowed_csrf_origins:
+    CSRF_TRUSTED_ORIGINS = [
+        allowed_csrf_origins.strip()
+        for allowed_csrf_origins in allowed_csrf_origins.split(",")
+    ]

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -227,3 +227,8 @@ AWS_QUERYSTRING_AUTH = False
 DEFAULT_FILE_STORAGE = os.getenv(
     "DEFAULT_FILE_STORAGE", "storages.backends.s3boto3.S3Boto3Storage"
 )
+
+# SECURITY
+# https://docs.djangoproject.com/en/4.0/ref/settings/#csrf-trusted-origins
+allowed_csrf_origins = os.getenv("CSRF_TRUSTED_ORIGINS", "")
+CSRF_TRUSTED_ORIGINS = [allowed_csrf_origins.strip() for allowed_csrf_origins in allowed_csrf_origins.split(",")]


### PR DESCRIPTION
Based on https://docs.djangoproject.com/en/4.0/ref/settings/#csrf-trusted-origins I could use this setting and I don't think it harms being here.