### PR TITLE
Run Github Action on PR events

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ name: "CI"
 #  - docker-publish-release – is only triggered on release events
 on:
   push:
+  pull_request:
   release:
     types: [ released ]
 


### PR DESCRIPTION
- Since we are getting external contributions, we need to enable these events so that the actions can run on PRs coming from forks.