### PR TITLE
Migrate to /v2/flush

### DIFF
--- a/src/chains/signals.py
+++ b/src/chains/signals.py
@@ -32,7 +32,7 @@ def _trigger_client_gateway_flush() -> None:
         logger.error("CGW_FLUSH_TOKEN is not set. Skipping hook call")
         return
 
-    url = urljoin(cgw_url, "/v1/flush/events")
+    url = urljoin(cgw_url, "/v2/flush")
     try:
         post = setup_session().post(
             url,

--- a/src/chains/signals.py
+++ b/src/chains/signals.py
@@ -32,9 +32,13 @@ def _trigger_client_gateway_flush() -> None:
         logger.error("CGW_FLUSH_TOKEN is not set. Skipping hook call")
         return
 
-    url = urljoin(cgw_url, f"/v1/flush/{cgw_flush_token}")
+    url = urljoin(cgw_url, "/v1/flush/events")
     try:
-        post = setup_session().post(url, json={"invalidate": "Chains"})
+        post = setup_session().post(
+            url,
+            json={"invalidate": "Chains"},
+            headers={"Authorization": f"Basic {cgw_flush_token}"},
+        )
         post.raise_for_status()
     except Exception as error:
         logger.error(error)

--- a/src/chains/tests/test_signals.py
+++ b/src/chains/tests/test_signals.py
@@ -14,26 +14,38 @@ class ChainNetworkHookTestCase(TestCase):
     def test_on_chain_update_hook_200(self) -> None:
         responses.add(
             responses.POST,
-            "http://127.0.0.1/v1/flush/example-token",
+            "http://127.0.0.1/v1/flush/events",
             status=200,
-            match=[responses.matchers.json_params_matcher({"invalidate": "Chains"})],
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic example-token"}
+                ),
+                responses.matchers.json_params_matcher({"invalidate": "Chains"}),
+            ],
         )
 
         ChainFactory.create()
 
         assert len(responses.calls) == 1
         assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[0].request.url == "http://127.0.0.1/v1/flush/events"
         assert (
-            responses.calls[0].request.url == "http://127.0.0.1/v1/flush/example-token"
+            responses.calls[0].request.headers.get("Authorization")
+            == "Basic example-token"
         )
 
     @responses.activate
     def test_on_chain_update_hook_400(self) -> None:
         responses.add(
             responses.POST,
-            "http://127.0.0.1/v1/flush/example-token",
+            "http://127.0.0.1/v1/flush/events",
             status=400,
-            match=[responses.matchers.json_params_matcher({"invalidate": "Chains"})],
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic example-token"}
+                ),
+                responses.matchers.json_params_matcher({"invalidate": "Chains"}),
+            ],
         )
 
         ChainFactory.create()
@@ -44,9 +56,14 @@ class ChainNetworkHookTestCase(TestCase):
     def test_on_chain_update_hook_500(self) -> None:
         responses.add(
             responses.POST,
-            "http://127.0.0.1/v1/flush/example-token",
+            "http://127.0.0.1/v1/flush/events",
             status=500,
-            match=[responses.matchers.json_params_matcher({"invalidate": "Chains"})],
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic example-token"}
+                ),
+                responses.matchers.json_params_matcher({"invalidate": "Chains"}),
+            ],
         )
 
         ChainFactory.create()
@@ -103,17 +120,24 @@ class FeatureHookTestCase(TestCase):
     def test_on_feature_create_hook_call(self) -> None:
         responses.add(
             responses.POST,
-            "http://127.0.0.1/v1/flush/example-token",
+            "http://127.0.0.1/v1/flush/events",
             status=200,
-            match=[responses.matchers.json_params_matcher({"invalidate": "Chains"})],
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic example-token"}
+                ),
+                responses.matchers.json_params_matcher({"invalidate": "Chains"}),
+            ],
         )
 
         Feature(key="Test Feature").save()
 
         assert len(responses.calls) == 1
         assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[0].request.url == "http://127.0.0.1/v1/flush/events"
         assert (
-            responses.calls[0].request.url == "http://127.0.0.1/v1/flush/example-token"
+            responses.calls[0].request.headers.get("Authorization")
+            == "Basic example-token"
         )
 
     @responses.activate
@@ -147,17 +171,24 @@ class WalletHookTestCase(TestCase):
     def test_on_wallet_create_hook_call(self) -> None:
         responses.add(
             responses.POST,
-            "http://127.0.0.1/v1/flush/example-token",
+            "http://127.0.0.1/v1/flush/events",
             status=200,
-            match=[responses.matchers.json_params_matcher({"invalidate": "Chains"})],
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic example-token"}
+                ),
+                responses.matchers.json_params_matcher({"invalidate": "Chains"}),
+            ],
         )
 
         Wallet(key="Test Wallet").save()
 
         assert len(responses.calls) == 1
         assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[0].request.url == "http://127.0.0.1/v1/flush/events"
         assert (
-            responses.calls[0].request.url == "http://127.0.0.1/v1/flush/example-token"
+            responses.calls[0].request.headers.get("Authorization")
+            == "Basic example-token"
         )
 
     @responses.activate
@@ -196,17 +227,24 @@ class GasPriceHookTestCase(TestCase):
     def test_on_gas_price_create_hook_call(self) -> None:
         responses.add(
             responses.POST,
-            "http://127.0.0.1/v1/flush/example-token",
+            "http://127.0.0.1/v1/flush/events",
             status=200,
-            match=[responses.matchers.json_params_matcher({"invalidate": "Chains"})],
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic example-token"}
+                ),
+                responses.matchers.json_params_matcher({"invalidate": "Chains"}),
+            ],
         )
 
         GasPriceFactory.create(chain=self.chain)
 
         assert len(responses.calls) == 1
         assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[0].request.url == "http://127.0.0.1/v1/flush/events"
         assert (
-            responses.calls[0].request.url == "http://127.0.0.1/v1/flush/example-token"
+            responses.calls[0].request.headers.get("Authorization")
+            == "Basic example-token"
         )
 
     @responses.activate

--- a/src/chains/tests/test_signals.py
+++ b/src/chains/tests/test_signals.py
@@ -14,7 +14,7 @@ class ChainNetworkHookTestCase(TestCase):
     def test_on_chain_update_hook_200(self) -> None:
         responses.add(
             responses.POST,
-            "http://127.0.0.1/v1/flush/events",
+            "http://127.0.0.1/v2/flush",
             status=200,
             match=[
                 responses.matchers.header_matcher(
@@ -28,7 +28,7 @@ class ChainNetworkHookTestCase(TestCase):
 
         assert len(responses.calls) == 1
         assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
-        assert responses.calls[0].request.url == "http://127.0.0.1/v1/flush/events"
+        assert responses.calls[0].request.url == "http://127.0.0.1/v2/flush"
         assert (
             responses.calls[0].request.headers.get("Authorization")
             == "Basic example-token"
@@ -38,7 +38,7 @@ class ChainNetworkHookTestCase(TestCase):
     def test_on_chain_update_hook_400(self) -> None:
         responses.add(
             responses.POST,
-            "http://127.0.0.1/v1/flush/events",
+            "http://127.0.0.1/v2/flush",
             status=400,
             match=[
                 responses.matchers.header_matcher(
@@ -56,7 +56,7 @@ class ChainNetworkHookTestCase(TestCase):
     def test_on_chain_update_hook_500(self) -> None:
         responses.add(
             responses.POST,
-            "http://127.0.0.1/v1/flush/events",
+            "http://127.0.0.1/v2/flush",
             status=500,
             match=[
                 responses.matchers.header_matcher(
@@ -120,7 +120,7 @@ class FeatureHookTestCase(TestCase):
     def test_on_feature_create_hook_call(self) -> None:
         responses.add(
             responses.POST,
-            "http://127.0.0.1/v1/flush/events",
+            "http://127.0.0.1/v2/flush",
             status=200,
             match=[
                 responses.matchers.header_matcher(
@@ -134,7 +134,7 @@ class FeatureHookTestCase(TestCase):
 
         assert len(responses.calls) == 1
         assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
-        assert responses.calls[0].request.url == "http://127.0.0.1/v1/flush/events"
+        assert responses.calls[0].request.url == "http://127.0.0.1/v2/flush"
         assert (
             responses.calls[0].request.headers.get("Authorization")
             == "Basic example-token"
@@ -171,7 +171,7 @@ class WalletHookTestCase(TestCase):
     def test_on_wallet_create_hook_call(self) -> None:
         responses.add(
             responses.POST,
-            "http://127.0.0.1/v1/flush/events",
+            "http://127.0.0.1/v2/flush",
             status=200,
             match=[
                 responses.matchers.header_matcher(
@@ -185,7 +185,7 @@ class WalletHookTestCase(TestCase):
 
         assert len(responses.calls) == 1
         assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
-        assert responses.calls[0].request.url == "http://127.0.0.1/v1/flush/events"
+        assert responses.calls[0].request.url == "http://127.0.0.1/v2/flush"
         assert (
             responses.calls[0].request.headers.get("Authorization")
             == "Basic example-token"
@@ -227,7 +227,7 @@ class GasPriceHookTestCase(TestCase):
     def test_on_gas_price_create_hook_call(self) -> None:
         responses.add(
             responses.POST,
-            "http://127.0.0.1/v1/flush/events",
+            "http://127.0.0.1/v2/flush",
             status=200,
             match=[
                 responses.matchers.header_matcher(
@@ -241,7 +241,7 @@ class GasPriceHookTestCase(TestCase):
 
         assert len(responses.calls) == 1
         assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
-        assert responses.calls[0].request.url == "http://127.0.0.1/v1/flush/events"
+        assert responses.calls[0].request.url == "http://127.0.0.1/v2/flush"
         assert (
             responses.calls[0].request.headers.get("Authorization")
             == "Basic example-token"


### PR DESCRIPTION
- Migrate to the new flush route – `/v2/flush`
- This route no longer requires the token to be set in the path. Instead, the token should be set in an `Authorization` header with the value of `Basic <token>`