### PR TITLE
Invalidate client gateway cache on safe-app update

### DIFF
--- a/src/safe_apps/signals.py
+++ b/src/safe_apps/signals.py
@@ -1,13 +1,25 @@
 import logging
 from typing import Any
 
+from django.conf import settings
 from django.core.cache import caches
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
+import clients.safe_client_gateway
+
 from .models import Provider, SafeApp
 
 logger = logging.getLogger(__name__)
+
+
+def _flush_cgw_safe_apps() -> None:
+    clients.safe_client_gateway.flush(
+        cgw_url=settings.CGW_URL,
+        cgw_flush_token=settings.CGW_FLUSH_TOKEN,
+        # Even though the payload is Chains, it actually invalidates all the safe-config related cache
+        json={"invalidate": "Chains"},
+    )
 
 
 @receiver(post_save, sender=SafeApp)
@@ -17,3 +29,4 @@ logger = logging.getLogger(__name__)
 def on_safe_app_update(sender: SafeApp, **kwargs: Any) -> None:
     logger.info("Clearing safe-apps cache")
     caches["safe-apps"].clear()
+    _flush_cgw_safe_apps()

--- a/src/safe_apps/tests/test_signals.py
+++ b/src/safe_apps/tests/test_signals.py
@@ -1,0 +1,169 @@
+import responses
+from django.test import TestCase, override_settings
+
+from safe_apps.models import SafeApp
+from safe_apps.tests.factories import ProviderFactory
+
+
+@override_settings(
+    CGW_URL="http://127.0.0.1",
+    CGW_FLUSH_TOKEN="example-token",
+)
+class SafeAppHookTestCase(TestCase):
+    @responses.activate
+    def test_on_safe_app_create_hook_call(self) -> None:
+        responses.add(
+            responses.POST,
+            "http://127.0.0.1/v2/flush",
+            status=200,
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic example-token"}
+                ),
+                responses.matchers.json_params_matcher({"invalidate": "Chains"}),
+            ],
+        )
+
+        SafeApp(chain_ids=[1]).save()
+
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[0].request.url == "http://127.0.0.1/v2/flush"
+        assert (
+            responses.calls[0].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
+
+    @responses.activate
+    def test_on_safe_app_update_hook_call(self) -> None:
+        responses.add(
+            responses.POST,
+            "http://127.0.0.1/v2/flush",
+            status=200,
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic example-token"}
+                ),
+                responses.matchers.json_params_matcher({"invalidate": "Chains"}),
+            ],
+        )
+
+        safe_app = SafeApp(chain_ids=[1])
+        safe_app.save()  # create
+        safe_app.name = "Test app"
+        safe_app.save()  # update
+
+        assert len(responses.calls) == 2
+        assert responses.calls[1].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[1].request.url == "http://127.0.0.1/v2/flush"
+        assert (
+            responses.calls[1].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
+
+    @responses.activate
+    def test_on_safe_app_delete_hook_call(self) -> None:
+        responses.add(
+            responses.POST,
+            "http://127.0.0.1/v2/flush",
+            status=200,
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic example-token"}
+                ),
+                responses.matchers.json_params_matcher({"invalidate": "Chains"}),
+            ],
+        )
+
+        safe_app = SafeApp(chain_ids=[1])
+        safe_app.save()  # create
+        safe_app.delete()  # delete
+
+        assert len(responses.calls) == 2
+        assert responses.calls[1].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[1].request.url == "http://127.0.0.1/v2/flush"
+        assert (
+            responses.calls[1].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
+
+
+@override_settings(
+    CGW_URL="http://127.0.0.1",
+    CGW_FLUSH_TOKEN="example-token",
+)
+class ProviderHookTestCase(TestCase):
+    @responses.activate
+    def test_on_provider_create_hook_call(self) -> None:
+        responses.add(
+            responses.POST,
+            "http://127.0.0.1/v2/flush",
+            status=200,
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic example-token"}
+                ),
+                responses.matchers.json_params_matcher({"invalidate": "Chains"}),
+            ],
+        )
+
+        ProviderFactory.create()
+
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[0].request.url == "http://127.0.0.1/v2/flush"
+        assert (
+            responses.calls[0].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
+
+    @responses.activate
+    def test_on_provider_update_hook_call(self) -> None:
+        responses.add(
+            responses.POST,
+            "http://127.0.0.1/v2/flush",
+            status=200,
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic example-token"}
+                ),
+                responses.matchers.json_params_matcher({"invalidate": "Chains"}),
+            ],
+        )
+
+        provider = ProviderFactory.create()  # create
+        provider.name = "Test Provider"
+        provider.save()  # update
+
+        assert len(responses.calls) == 2
+        assert responses.calls[1].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[1].request.url == "http://127.0.0.1/v2/flush"
+        assert (
+            responses.calls[1].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
+
+    @responses.activate
+    def test_on_provider_delete_hook_call(self) -> None:
+        responses.add(
+            responses.POST,
+            "http://127.0.0.1/v2/flush",
+            status=200,
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic example-token"}
+                ),
+                responses.matchers.json_params_matcher({"invalidate": "Chains"}),
+            ],
+        )
+
+        provider = ProviderFactory.create()  # create
+        provider.delete()  # delete
+
+        assert len(responses.calls) == 2
+        assert responses.calls[1].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[1].request.url == "http://127.0.0.1/v2/flush"
+        assert (
+            responses.calls[1].request.headers.get("Authorization")
+            == "Basic example-token"
+        )


### PR DESCRIPTION
- Invalidate the Safe Client Gateway cache when a `SafeApp` is added, updated or deleted
- The payload used in `flush` endpoint refers to `Chains` but this is because there's no distinction on the caching layer of the Safe Client Gateway between `Chain` and `SafeApp`