### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # the repo. Unless a later match takes precedence,
 * @gnosis/safe-services
 
-/src/safe_apps @mikheevm
+/src/safe_apps @mikheevm @gnosis/safe-services


### PR DESCRIPTION
- The `/src/safe_apps` is taking precedence over `*` so @mikheevm was the only one requested for reviews
- Switching the order of the statements like:

```
/src/safe_apps @mikheevm

* @gnosis/safe-services
``` 

would result in @mikheevm not getting assigned for review