### PR TITLE
Revert "Set OTP for admin access (#371)"

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,14 +14,6 @@ PYTHONDONTWRITEBYTECODE=true
 # This should never be set to true in production but it should be enabled in dev.
 DEBUG=false
 
-# Enable One-Time-Password for admin access
-# If this setting is enabled, access to the Django Admin panel will require a
-# one time password from a registered device.
-# If you have no registered devices you can set a static token for onboarding to the admin:
-# python src/manage.py addstatictoken <username>
-# See: https://django-otp-official.readthedocs.io/en/stable/overview.html#addstatictoken
-DJANGO_OTP_ADMIN=true
-
 # Root log level (default is INFO)
 # Possible values are DEBUG | INFO | WARNING | ERROR | CRITICAL
 ROOT_LOG_LEVEL=INFO

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ Django==4.0.3
 django-cors-headers==3.11.0
 djangorestframework==3.13.1
 djangorestframework-camel-case==1.3.0
-django-otp[qrcode]==1.1.3
 django-storages==1.12.3
 django-stubs-ext==0.3.1
 drf-yasg[validation]==1.20.0

--- a/src/config/admin.py
+++ b/src/config/admin.py
@@ -1,5 +1,0 @@
-from django.contrib.admin.apps import AdminConfig
-
-
-class OTPAdminConfig(AdminConfig):
-    default_site = "django_otp.admin.OTPAdminSite"

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -49,6 +49,7 @@ INSTALLED_APPS = [
     "about.apps.AboutAppConfig",
     "chains.apps.AppsConfig",
     "safe_apps.apps.AppsConfig",
+    "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.sessions",
@@ -56,9 +57,6 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "rest_framework",
     "drf_yasg",
-    "django_otp",
-    "django_otp.plugins.otp_totp",
-    "django_otp.plugins.otp_static",
 ]
 
 MIDDLEWARE = [
@@ -69,18 +67,9 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "django_otp.middleware.OTPMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
-
-DJANGO_OTP_ADMIN = strtobool(os.getenv("DJANGO_OTP_ADMIN", "true"))
-if DJANGO_OTP_ADMIN:
-    # Use OTP admin
-    INSTALLED_APPS.append("config.admin.OTPAdminConfig")
-else:
-    # Use Default admin
-    INSTALLED_APPS.append("django.contrib.admin")
 
 CACHES = {
     "default": {


### PR DESCRIPTION
This reverts commit 2d8fa7fb5ca244c37e4817fbe3aa40cacbe26f53.

- Reverts the OTP admin feature

This feature is not used on production and the goal is to move towards using `SSO` with the admin. 